### PR TITLE
Add blog shortcode feature

### DIFF
--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -701,9 +701,10 @@ class EverPsBlogPost extends ObjectModel
         $limit = null,
         $post_status = 'published',
         $is_feed = false,
-        $starred = false
+        $starred = false,
+        $orderWay = 'DESC'
     ) {
-        $cache_id = 'EverPsBlogPost::getPostsByTag_'
+        $cache_id = 'EverPsBlogPost::getPostsByCategory_'
         . (int) $id_lang
         . '_'
         . (int) $id_shop
@@ -718,7 +719,9 @@ class EverPsBlogPost extends ObjectModel
         . '_'
         . $is_feed
         . '_'
-        . $starred;
+        . $starred
+        . '_'
+        . $orderWay;
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
             if (!(int) $limit <= 0) {
@@ -746,7 +749,7 @@ class EverPsBlogPost extends ObjectModel
             if ((bool) $starred === true) {
                 $sql->where('bp.starred = 1');
             }
-            $sql->orderBy('bp.date_add DESC');
+            $sql->orderBy('bp.date_add ' . pSQL($orderWay));
             $sql->limit((int) $limit, (int) $start);
             $posts = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
             $return = [];

--- a/views/templates/hook/shortcode.tpl
+++ b/views/templates/hook/shortcode.tpl
@@ -1,0 +1,19 @@
+<div class="everpsblog-shortcode row">
+    {foreach from=$posts item=item}
+    <div class="col-12 col-md-4 article everpsblog mb-3" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+        <div class="col-12 article-img">
+            <img src="{$item->featured_image|escape:'htmlall':'UTF-8'}" class="img img-fluid" alt="{$item->title|escape:'htmlall':'UTF-8'}" />
+        </div>
+        <div class="col-12">
+            <h3 class="everpsblog article-content h3" id="everpsblog-post-title-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+                <a href="{$link->getModuleLink('everpsblog', 'post', ['id_ever_post' => $item->id_ever_post, 'link_rewrite' => $item->link_rewrite])|escape:'htmlall':'UTF-8'}" class="{$blogcolor|escape:'htmlall':'UTF-8'}">
+                    {$item->title|escape:'htmlall':'UTF-8'}
+                </a>
+            </h3>
+            <div class="everpsblogcontent rte" id="everpsblog-post-content-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+                {if isset($item->excerpt) && !empty($item->excerpt)}{$item->excerpt|escape:'htmlall':'UTF-8'}{else}{$item->content|escape:'htmlall':'UTF-8'}{/if}
+            </div>
+        </div>
+    </div>
+    {/foreach}
+</div>


### PR DESCRIPTION
## Summary
- allow sorting when getting posts by category
- inject shortcode parsing into HTML output
- implement shortcode parser and template to embed post lists

## Testing
- `php -l everpsblog.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684816f3f93c83228236ba8e0e8103b5