### PR TITLE
Add WooCommerce REST importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ A detailed guide in French is available at <https://www.team-ever.com/prestashop
 ### Upgrade from 5.x
 When updating to version 6.0.0, run the module upgrade from the back office. The `upgrade_module_6_0_0` script creates the new multishop association tables and migrates existing `id_shop` values so your posts, categories, authors, tags and images remain linked to the proper shops.
 
+### WooCommerce REST Import
+You can now fetch posts from a WooCommerce store using its REST API. Configure the API URL and credentials in the module settings and click **Import WooCommerce posts**. Tags and linked product IDs detected in the API data are also imported.
+
 ---
 
 ## Français


### PR DESCRIPTION
## Summary
- fix HTML encoding on imported image alt text
- allow decoding of special characters in imported titles
- support featured images from WordPress XML
- add WooCommerce REST API import option and helper
- document REST API import in README
- include tag and product associations when importing via REST
- sanitize URLs when downloading remote images

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483ef5d11483229c4091021321670a