### PR TITLE
Add WordPress REST import

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ When updating to version 6.0.0, run the module upgrade from the back office. The
 ### WooCommerce REST Import
 You can now fetch posts from a WooCommerce store using its REST API. Configure the API URL and credentials in the module settings and click **Import WooCommerce posts**. Tags and linked product IDs detected in the API data are also imported.
 
+### WordPress REST Import
+If WooCommerce is not installed, you can still import posts using the standard WordPress REST API. Provide the API URL in the module settings and click **Import WordPress posts** to fetch all blog content.
+
 ---
 
 ## Français


### PR DESCRIPTION
## Summary
- support importing blog posts via the standard WordPress REST API
- document the WordPress REST import option in README

## Testing
- `php -l everpsblog.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684852889f5c83228931bb14aa7a7f69