### PR TITLE
Fix buildSortLink visibility

### DIFF
--- a/classes/EverPsBlogSortOrders.php
+++ b/classes/EverPsBlogSortOrders.php
@@ -56,7 +56,7 @@ class EverPsBlogSortOrders
         return $sortOrders;
     }
 
-    private function buildSortLink(string $orderBy, string $orderWay): string
+    public static function buildSortLink(string $orderBy, string $orderWay): string
     {
         // Récupération de l'URL courante
         $url = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]$_SERVER[REQUEST_URI]";


### PR DESCRIPTION
## Summary
- make `buildSortLink` static and public

## Testing
- `bash tools/php_syntax_check.sh` *(fails: PHP executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684909602bc48322a110931bf9c448b9