### PR TITLE
Add product display on blog post columns

### DIFF
--- a/views/templates/hook/columns.tpl
+++ b/views/templates/hook/columns.tpl
@@ -34,6 +34,17 @@
     </ul>
 </div>
 {/if}
+
+{if isset($ps_products) && $ps_products}
+<div class="columns_everblog_wrapper products_wrapper">
+    <p class="text-uppercase h6 hidden-sm-down">{l s='Linked products' mod='everpsblog'}</p>
+    <div class="products">
+        {foreach from=$ps_products item="product"}
+            {include file="catalog/_partials/miniatures/product.tpl" product=$product}
+        {/foreach}
+    </div>
+</div>
+{/if}
 {if isset($showTags) && $showTags && isset($tags) && !empty($tags)}
 <div class="columns_everblog_wrapper tag_wrapper">
     <p class="text-uppercase h6 hidden-sm-down">{l s='Tags from the blog' mod='everpsblog'}</p>


### PR DESCRIPTION
## Summary
- show linked products in column hooks when viewing a blog post
- add configuration option to toggle column products

## Testing
- `php -l everpsblog.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849092450108322a4eb778b9b509975