### PR TITLE
Fix post retrieval pagination

### DIFF
--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -219,7 +219,7 @@ class EverPsBlogPost extends ObjectModel
         . '_'
         . $starred;
         if (!Cache::isStored($cache_id)) {
-            if (!(int) $limit <= 0) {
+            if ((int) $limit <= 0) {
                 $limit = (int) Configuration::get('EVERPSBLOG_PAGINATION');
             }
             $context = Context::getContext();
@@ -599,7 +599,7 @@ class EverPsBlogPost extends ObjectModel
         . (bool) $starred;
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
-            if (!(int) $limit <= 0) {
+            if ((int) $limit <= 0) {
                 $limit = (int) Configuration::get('EVERPSBLOG_PAGINATION');
             }
             $sql = new DbQuery;
@@ -724,7 +724,7 @@ class EverPsBlogPost extends ObjectModel
         . $orderWay;
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
-            if (!(int) $limit <= 0) {
+            if ((int) $limit <= 0) {
                 $limit = (int) Configuration::get('EVERPSBLOG_PAGINATION');
             }
             $sql = new DbQuery;
@@ -848,7 +848,7 @@ class EverPsBlogPost extends ObjectModel
         . (bool) $starred;
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
-            if (!(int) $limit <= 0) {
+            if ((int) $limit <= 0) {
                 $limit = (int) Configuration::get('EVERPSBLOG_PAGINATION');
             }
             $sql = new DbQuery;
@@ -958,7 +958,7 @@ class EverPsBlogPost extends ObjectModel
         . $post_status;
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
-            if (!(int) $limit <= 0) {
+            if ((int) $limit <= 0) {
                 $limit = (int) Configuration::get('EVERPSBLOG_PAGINATION');
             }
             $sql = new DbQuery;

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -179,7 +179,7 @@ class EverPsBlogcategoryModuleFrontController extends EverPsBlogModuleFrontContr
                 'post_number' => (int) $this->post_number,
                 'pagination' => $pagination,
                 'category' => $this->category,
-                'posts' => array_map(function ($post) { return (array) $post; }, $posts ?: []),
+                'posts' => $posts,
                 'default_lang' => (int) $this->context->language->id,
                 'id_lang' => $this->context->language->id,
                 'blogImg_dir' => Tools::getHttpHost(true) . __PS_BASE_URI__.'modules/' . $this->module->name . '/views/img/',


### PR DESCRIPTION
## Summary
- correct pagination logic to load category posts
- pass post objects directly to template instead of arrays

## Testing
- `php -l classes/EverPsBlogPost.php` *(fails: php not installed)*
- `php -l controllers/front/category.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68490f025aa08322af8173589c6bdf66