### PR TITLE
Remove unused smarty fetch calls

### DIFF
--- a/controllers/admin/AdminEverPsBlogAuthorController.php
+++ b/controllers/admin/AdminEverPsBlogAuthorController.php
@@ -233,9 +233,6 @@ class AdminEverPsBlogAuthorController extends ModuleAdminController
         $this->html .= $lists;
         $this->html .= $this->context->smarty->fetch(
             _PS_MODULE_DIR_
-        );
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
             . '/' . $this->module->name . '/views/templates/admin/footer.tpl'
         );
 

--- a/controllers/admin/AdminEverPsBlogCategoryController.php
+++ b/controllers/admin/AdminEverPsBlogCategoryController.php
@@ -250,9 +250,6 @@ class AdminEverPsBlogCategoryController extends ModuleAdminController
         $this->html .= $lists;
         $this->html .= $this->context->smarty->fetch(
             _PS_MODULE_DIR_
-        );
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
             . '/' . $this->module->name . '/views/templates/admin/footer.tpl'
         );
 

--- a/controllers/admin/AdminEverpsBlogCommentController.php
+++ b/controllers/admin/AdminEverpsBlogCommentController.php
@@ -223,9 +223,6 @@ class AdminEverPsBlogCommentController extends ModuleAdminController
         $this->html .= $lists;
         $this->html .= $this->context->smarty->fetch(
             _PS_MODULE_DIR_
-        );
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
             .'/everpsblog/views/templates/admin/footer.tpl'
         );
 

--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -321,9 +321,6 @@ class AdminEverPsBlogPostController extends ModuleAdminController
         $this->html .= $lists;
         $this->html .= $this->context->smarty->fetch(
             _PS_MODULE_DIR_
-        );
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
             .'/' . $this->module->name . '/views/templates/admin/footer.tpl'
         );
         return $this->html;


### PR DESCRIPTION
## Summary
- remove stray `_PS_MODULE_DIR_` smarty fetch calls

## Testing
- `php -l controllers/admin/AdminEverPsBlogCategoryController.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68491eb150348322a07204e5808730a0