### PR TITLE
Display blog categories in column

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -156,6 +156,7 @@ class EverPsBlog extends Module
             && Configuration::updateValue('EVERPSBLOG_EXCERPT', '150')
             && Configuration::updateValue('EVERPSBLOG_TITLE_LENGTH', '150')
             && Configuration::updateValue('EVERBLOG_PRODUCT_COLUMNS', 1)
+            && Configuration::updateValue('EVERBLOG_CATEG_COLUMNS', 1)
             && Configuration::updateValue('EVERPSBLOG_BLOG_LAYOUT', 'layouts/layout-right-column.tpl')
             && Configuration::updateValue('EVERPSBLOG_POST_LAYOUT', 'layouts/layout-right-column.tpl')
             && Configuration::updateValue('EVERPSBLOG_CAT_LAYOUT', 'layouts/layout-right-column.tpl')
@@ -175,6 +176,7 @@ class EverPsBlog extends Module
             'hook_module',
             'id_module = ' . (int) $this->id
         );
+        Configuration::deleteByName('EVERBLOG_CATEG_COLUMNS');
         return parent::uninstall()
             && $this->uninstallModuleTab('AdminEverPsBlog')
             && $this->uninstallModuleTab('AdminEverPsBlogPost')

--- a/views/templates/hook/columns.tpl
+++ b/views/templates/hook/columns.tpl
@@ -21,17 +21,13 @@
 {if isset($showCategories) && $showCategories && isset($categories) && !empty($categories)}
 <div class="columns_everblog_wrapper category_wrapper">
     <p class="text-uppercase h6 hidden-sm-down">{l s='Categories from the blog' mod='everpsblog'}</p>
-    <ul>
-{foreach from=$categories item=category}
-{if $category.is_root_category == 0}
-    <li>
-        <a href="{$link->getModuleLink('everpsblog', 'category',['id_ever_category'=>$category.id_ever_category, 'link_rewrite'=>$category.link_rewrite])|escape:'htmlall':'UTF-8'}" class="category" title="{$category.title|escape:'htmlall':'UTF-8'}">
+    {foreach from=$categories item=category}
+    {if $category.is_root_category == 0}
+        <a href="{$link->getModuleLink('everpsblog', 'category', ['id_ever_category' => $category.id_ever_category, 'link_rewrite' => $category.link_rewrite])|escape:'htmlall':'UTF-8'}" class="category d-block" title="{$category.title|escape:'htmlall':'UTF-8'}">
             {$category.title|escape:'htmlall':'UTF-8'}
         </a>
-    </li>
-{/if}
-{/foreach}
-    </ul>
+    {/if}
+    {/foreach}
 </div>
 {/if}
 


### PR DESCRIPTION
## Summary
- add missing configuration key `EVERBLOG_CATEG_COLUMNS` during install
- remove this configuration on uninstall
- show sidebar categories as basic links

## Testing
- `php -l everpsblog.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68491d3c6bac8322b9abfedf264d1f9c