### PR TITLE
Fix HTML sanitation on WordPress REST import

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -3526,9 +3526,11 @@ class EverPsBlog extends Module
                     $content = $this->replaceAndDownloadImages(
                         $this->cleanWpShortcodes($data->content->rendered)
                     );
+                    $content = Tools::purifyHTML($content);
                     $excerpt = $this->replaceAndDownloadImages(
                         $this->cleanWpShortcodes($data->excerpt->rendered)
                     );
+                    $excerpt = Tools::purifyHTML($excerpt);
                     $post->title[$language['id_lang']] = html_entity_decode($data->title->rendered, ENT_QUOTES, 'UTF-8');
                     $post->meta_title[$language['id_lang']] = html_entity_decode($data->title->rendered, ENT_QUOTES, 'UTF-8');
                     $post->meta_description[$language['id_lang']] = Tools::substr(strip_tags($content), 0, 160);


### PR DESCRIPTION
## Summary
- clean WordPress REST API post content with `Tools::purifyHTML`

## Testing
- `php -l everpsblog.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684921d95f688322a63edcca96d8fec5