### PR TITLE
Fix category page post template

### DIFF
--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -103,7 +103,7 @@
 <div class="container">
 {hook h="displayBeforeEverLoop"}
 {foreach from=$posts item=item}
-{include file='module:everpsblog/views/templates/front/loop/post_array.tpl'}
+{include file='module:everpsblog/views/templates/front/loop/post_object.tpl'}
 {/foreach}
 </div>
 {if isset($post_number) && $post_number > 0}


### PR DESCRIPTION
## Summary
- use `post_object.tpl` for category listing

## Testing
- `php` not installed; no tests run

------
https://chatgpt.com/codex/tasks/task_e_684922cc61d483229a96879b4596fd4a