### PR TITLE
Add search feature

### DIFF
--- a/controllers/front/search.php
+++ b/controllers/front/search.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+require_once(dirname(__FILE__).'/../../classes/controller/FrontController.php');
+
+class EverPsBlogsearchModuleFrontController extends EverPsBlogModuleFrontController
+{
+    protected $query;
+    public $post_number;
+    public $controller_name = 'search';
+
+    public function init()
+    {
+        $this->query = Tools::getValue('s');
+        parent::init();
+    }
+
+    public function l($string, $specific = false, $class = null, $addslashes = false, $htmlentities = true)
+    {
+        return Context::getContext()->getTranslator()->trans(
+            $string,
+            [],
+            'Modules.Everpsblog.search'
+        );
+    }
+
+    public function initContent()
+    {
+        parent::initContent();
+        if (!$this->query) {
+            Tools::redirect($this->context->link->getModuleLink('everpsblog', 'blog'));
+        }
+        $this->post_number = EverPsBlogPost::countPostsBySearch(
+            $this->query,
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id
+        );
+        $pagination = $this->getTemplateVarPagination($this->post_number);
+        $posts = EverPsBlogPost::searchPost(
+            $this->query,
+            (int) $this->context->shop->id,
+            (int) $this->context->language->id,
+            (int) $pagination['items_shown_from'] - 1,
+            (int) Configuration::get('EVERPSBLOG_PAGINATION')
+        );
+        $page = $this->context->controller->getTemplateVarPage();
+        $page['meta']['title'] = $this->l('Search results for') . ' ' . $this->query;
+        $page['meta']['description'] = $page['meta']['title'];
+        $page['meta']['robots'] = 'noindex, follow';
+        $this->context->smarty->assign('page', $page);
+        $this->context->smarty->assign([
+            'blogcolor' => Configuration::get('EVERBLOG_CSS_FILE'),
+            'blog_type' => Configuration::get('EVERPSBLOG_TYPE'),
+            'paginated' => Tools::getValue('page'),
+            'post_number' => (int) $this->post_number,
+            'pagination' => $pagination,
+            'posts' => $posts,
+            'query' => $this->query,
+            'default_lang' => (int) $this->context->language->id,
+            'id_lang' => $this->context->language->id,
+            'blogImg_dir' => Tools::getHttpHost(true) . __PS_BASE_URI__ . 'modules/everpsblog/views/img/',
+            'animated' => Configuration::get('EVERBLOG_ANIMATE'),
+        ]);
+        $this->setTemplate('module:everpsblog/views/templates/front/search.tpl');
+    }
+
+    public function getLayout()
+    {
+        return Configuration::get('EVERPSBLOG_BLOG_LAYOUT');
+    }
+
+    public function getBreadcrumbLinks()
+    {
+        $breadcrumb = parent::getBreadcrumbLinks();
+        $breadcrumb['links'][] = [
+            'title' => $this->l('Blog'),
+            'url' => $this->context->link->getModuleLink('everpsblog', 'blog'),
+        ];
+        $breadcrumb['links'][] = [
+            'title' => $this->l('Search results'),
+            'url' => $this->context->link->getModuleLink('everpsblog', 'search', ['s' => $this->query]),
+        ];
+        return $breadcrumb;
+    }
+}

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -228,6 +228,16 @@ class EverPsBlog extends Module
                     'controller' => 'blog',
                 ],
             ],
+            'module-everpsblog-search' => [
+                'controller' => 'search',
+                'rule' => $base_route . '/search',
+                'keywords' => [
+                ],
+                'params' => [
+                    'fc' => 'module',
+                    'module' => 'everpsblog',
+                ],
+            ],
             'module-everpsblog-category' => [
                 'controller' => 'category',
                 'rule' => $base_route . '/category{/:id_ever_category}-{:link_rewrite}',
@@ -950,6 +960,7 @@ class EverPsBlog extends Module
         Configuration::deleteByName('PS_ROUTE_module-everpsblog-blog');
         Configuration::deleteByName('PS_ROUTE_module-everpsblog-category');
         Configuration::deleteByName('PS_ROUTE_module-everpsblog-post');
+        Configuration::deleteByName('PS_ROUTE_module-everpsblog-search');
         Configuration::deleteByName('PS_ROUTE_module-everpsblog-tag');
         Configuration::deleteByName('PS_ROUTE_module-everpsblog-author');
         Hook::exec('hookModuleRoutes');

--- a/views/templates/front/author.tpl
+++ b/views/templates/front/author.tpl
@@ -74,6 +74,12 @@
         {if isset($allow_feed) && $allow_feed}
         <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$author->nickhandle|escape:'htmlall':'UTF-8'}</a>
         {/if}
+<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
+    <div class="input-group">
+        <input class="form-control" type="search" name="s" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+    </div>
+</form>
         {if isset($paginated) && !$paginated}
         <div class="row author-header">
             <img class="img img-fluid author-featured-image featured-image" src="{$featured_image|escape:'htmlall':'UTF-8'}" alt="{$author->nickhandle|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$author->nickhandle|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -77,6 +77,12 @@
 {if isset($allow_feed) && $allow_feed}
 <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$category->title|escape:'htmlall':'UTF-8'}</a>
 {/if}
+<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
+    <div class="input-group">
+        <input class="form-control" type="search" name="s" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+    </div>
+</form>
 {if isset($paginated) && !$paginated}
 <div class="container">
     <div class="row categoryinfos d-none">

--- a/views/templates/front/search.tpl
+++ b/views/templates/front/search.tpl
@@ -1,0 +1,35 @@
+{*
+ * 2019-2025 Team Ever
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ *  @author    Team Ever <https://www.team-ever.com/>
+ *  @copyright 2019-2025 Team Ever
+ *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*}
+
+{extends file='page.tpl'}
+
+{block name='content'}
+<h1 class="text-center">{l s='Search results for' mod='everpsblog'} "{$query|escape:'htmlall':'UTF-8'}"</h1>
+{if isset($post_number) && $post_number > 0}
+<div class="row mt-2">
+    {foreach from=$posts item=item}
+        {include file='module:everpsblog/views/templates/front/loop/post_array.tpl'}
+    {/foreach}
+</div>
+<div class="row">
+    {include file='_partials/pagination.tpl' pagination=$pagination}
+</div>
+{else}
+<div class="alert alert-info">{l s='No post found for this search.' mod='everpsblog'}</div>
+{/if}
+{/block}

--- a/views/templates/front/tag.tpl
+++ b/views/templates/front/tag.tpl
@@ -52,6 +52,12 @@
         <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$tag->title|escape:'htmlall':'UTF-8'}</a>
         {/if}
     </div>
+<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
+    <div class="input-group">
+        <input class="form-control" type="search" name="s" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+    </div>
+</form>
 </div>
 {if isset($paginated) && !$paginated}
 <div class="container">


### PR DESCRIPTION
## Summary
- support blog post search with a new front controller
- count posts for pagination
- register a new SEO route for search
- display search bar on category, tag and author pages
- add template for search results

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684970d2d0b883228621e0a6cf44288f