### PR TITLE
Adjust blog search bar placement

### DIFF
--- a/views/templates/front/author.tpl
+++ b/views/templates/front/author.tpl
@@ -70,16 +70,18 @@
 {hook h="displayBeforeEverAuthor" everblogauthor=$author}
 <div class="content" itemscope="itemscope" itemtype="http://schema.org/Blog">
     <div class="container" itemscope="itemscope" itemtype="http://schema.org/BlogAuthoring" itemprop="blogAuthor">
-        <h1 itemprop="headline" class="text-center">{$author->nickhandle|escape:'htmlall':'UTF-8'}</h1>
+        <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
+            <h1 itemprop="headline" class="text-center flex-grow-1 m-0">{$author->nickhandle|escape:'htmlall':'UTF-8'}</h1>
+            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+                <div class="input-group">
+                    <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+                    <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+                </div>
+            </form>
+        </div>
         {if isset($allow_feed) && $allow_feed}
         <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$author->nickhandle|escape:'htmlall':'UTF-8'}</a>
         {/if}
-<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
-    <div class="input-group">
-        <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
-        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
-    </div>
-</form>
         {if isset($paginated) && !$paginated}
         <div class="row author-header">
             <img class="img img-fluid author-featured-image featured-image" src="{$featured_image|escape:'htmlall':'UTF-8'}" alt="{$author->nickhandle|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$author->nickhandle|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">

--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -67,16 +67,18 @@
 {/block}
 
 {block name="page_content"}
-<h1 class="text-center">{l s='Our blog' mod='everpsblog'}</h1>
+<div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
+    <h1 class="text-center flex-grow-1 m-0">{l s='Our blog' mod='everpsblog'}</h1>
+    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+        <div class="input-group">
+            <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+            <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+        </div>
+    </form>
+</div>
 {if isset($allow_feed) && $allow_feed}
 <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$page.meta.title|escape:'htmlall':'UTF-8'}</a>
 {/if}
-<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
-    <div class="input-group">
-        <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
-        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
-    </div>
-</form>
 <span class="paginated float-end d-none">{if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}</span>
 {if isset($paginated) && !$paginated}
 {if isset($default_blog_top_text) && $default_blog_top_text}

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -73,16 +73,18 @@
   <img src="{$featured_image|escape:'htmlall':'UTF-8'}" class="img img-fluid category-featured-image featured-image" alt="{$category->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$category->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">
 </div>
 {/if}
-<h1 class="text-center">{$category->title|escape:'htmlall':'UTF-8'}</h1>
+<div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
+    <h1 class="text-center flex-grow-1 m-0">{$category->title|escape:'htmlall':'UTF-8'}</h1>
+    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+        <div class="input-group">
+            <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+            <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+        </div>
+    </form>
+</div>
 {if isset($allow_feed) && $allow_feed}
 <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$category->title|escape:'htmlall':'UTF-8'}</a>
 {/if}
-<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
-    <div class="input-group">
-        <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
-        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
-    </div>
-</form>
 {if isset($paginated) && !$paginated}
 <div class="container">
     <div class="row categoryinfos d-none">

--- a/views/templates/front/tag.tpl
+++ b/views/templates/front/tag.tpl
@@ -47,18 +47,19 @@
             <img src="{$featured_image|escape:'htmlall':'UTF-8'}" class="img img-fluid mx-auto d-block" alt="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:htmlall:'UTF-8'}" title="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:htmlall:'UTF-8'}">
         </div>
         {/if}
-        <h1 class="text-center">{$tag->title|escape:'htmlall':'UTF-8'}</h1>
+        <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
+            <h1 class="text-center flex-grow-1 m-0">{$tag->title|escape:'htmlall':'UTF-8'}</h1>
+            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+                <div class="input-group">
+                    <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
+                    <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
+                </div>
+            </form>
+        </div>
         {if isset($allow_feed) && $allow_feed}
         <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$tag->title|escape:'htmlall':'UTF-8'}</a>
         {/if}
     </div>
-<form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search mb-3">
-    <div class="input-group">
-        <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
-        <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>
-    </div>
-</form>
-</div>
 {if isset($paginated) && !$paginated}
 <div class="container">
     <div class="row tagcontent">


### PR DESCRIPTION
## Summary
- align search form next to page titles on blog-related pages

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a5a0a617c8322831a9be2468b6911