### PR TITLE
Fix blog post title alignment and product page featured image

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -2478,7 +2478,7 @@ class EverPsBlog extends Module
             'id_lang' => (int) $this->context->language->id,
             'blogImg_dir' => $siteUrl.'/modules/everpsblog/views/img/',
             'animated' => $animate,
-            'show_featured_post' => true,
+            'show_featured_post' => (bool) Configuration::get('EVERBLOG_SHOW_FEAT_POST'),
         ]);
         return $this->display(__FILE__, 'views/templates/hook/product.tpl');
     }

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -86,7 +86,7 @@
             <img class="img img-fluid post-featured-image featured-image" src="{$featured_image|escape:'htmlall':'UTF-8'}" alt="{$post->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">
         </div>
         {/if}
-        <h1 class="text-center">{$post->title|escape:'htmlall':'UTF-8'}</h1>
+        <h1 class="text-start">{$post->title|escape:'htmlall':'UTF-8'}</h1>
         <p class="postpublished text-start">
             {$post->date_add|date_format:'%d %B %Y'|escape:'htmlall':'UTF-8'}
         </p>


### PR DESCRIPTION
## Summary
- align blog post titles to the left on the post page
- control display of featured post image on product page using `EVERBLOG_SHOW_FEAT_POST`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a0b82340832299ac8a1322a97f82