### PR TITLE
Fix blog search forms to ignore Doofinder

### DIFF
--- a/views/templates/front/author.tpl
+++ b/views/templates/front/author.tpl
@@ -72,7 +72,7 @@
     <div class="container" itemscope="itemscope" itemtype="http://schema.org/BlogAuthoring" itemprop="blogAuthor">
         <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
             <h1 itemprop="headline" class="text-center flex-grow-1 m-0">{$author->nickhandle|escape:'htmlall':'UTF-8'}</h1>
-            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3" data-doofinder-ignore="true">
                 <div class="input-group">
                     <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
                     <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>

--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -69,7 +69,7 @@
 {block name="page_content"}
 <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
     <h1 class="text-center flex-grow-1 m-0">{l s='Our blog' mod='everpsblog'}</h1>
-    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3" data-doofinder-ignore="true">
         <div class="input-group">
             <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
             <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -75,7 +75,7 @@
 {/if}
 <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
     <h1 class="text-center flex-grow-1 m-0">{$category->title|escape:'htmlall':'UTF-8'}</h1>
-    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+    <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3" data-doofinder-ignore="true">
         <div class="input-group">
             <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
             <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>

--- a/views/templates/front/tag.tpl
+++ b/views/templates/front/tag.tpl
@@ -49,7 +49,7 @@
         {/if}
         <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
             <h1 class="text-center flex-grow-1 m-0">{$tag->title|escape:'htmlall':'UTF-8'}</h1>
-            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3">
+            <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3" data-doofinder-ignore="true">
                 <div class="input-group">
                     <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search the blog...' mod='everpsblog'}" required />
                     <button class="btn btn-secondary" type="submit">{l s='Search' mod='everpsblog'}</button>


### PR DESCRIPTION
## Summary
- disable Doofinder on blog search forms by adding `data-doofinder-ignore` to each form

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a8fa280b883228c7f70760bd23660