### PR TITLE
Hide blog subcategory listings

### DIFF
--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -89,13 +89,14 @@
 {if isset($prettyblocks_enabled) && $prettyblocks_enabled}
 {widget name="prettyblocks" zone_name="displayBeforeBlog"}
 {/if}
-<div class="row mt-2">
+{* Hide categories list on blog pages *}
+{*<div class="row mt-2">
 {foreach from=$evercategory item=item}
     {if !$item.is_root_category}
     {include file='module:everpsblog/views/templates/front/loop/category_array.tpl'}
     {/if}
 {/foreach}
-</div>
+</div>*}
 {/if}
 
 {if isset($post_number) && $post_number > 0}

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -98,7 +98,8 @@
     </div>
 </div>
 {/if}
-{if isset($children_categories) && $children_categories && !empty($children_categories)}
+{* Hide children categories *}
+{*{if isset($children_categories) && $children_categories && !empty($children_categories)}
 <div class="row mt-2">
 {foreach from=$children_categories item=item}
     {if !$item->is_root_category}
@@ -106,7 +107,7 @@
     {/if}
 {/foreach}
 </div>
-{/if}
+{/if}*}
 {if isset($post_number) && $post_number > 0}
 <div class="container">
     <div class="row">


### PR DESCRIPTION
## Summary
- comment out the child-category loop in `category.tpl`
- comment out the category list loop in `blog.tpl`

## Testing
- `bash tools/php_syntax_check.sh` *(fails: PHP executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a90d885c08322a71cd5d56ad20271