### PR TITLE
Remove featured image from post page

### DIFF
--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -416,7 +416,8 @@ class EverPsBlogpostModuleFrontController extends EverPsBlogModuleFrontControlle
                 'blogcolor' => Configuration::get('EVERBLOG_CSS_FILE'),
                 'blog_type' => Configuration::get('EVERPSBLOG_TYPE'),
                 'featured_image' => $file_url,
-                'show_featured_post' => true,
+                // Hide featured image on the post page only
+                'show_featured_post' => false,
                 'author_cover' => $this->author_cover,
                 'author' => $this->author,
                 'social_share_links' => $social_share_links,


### PR DESCRIPTION
## Summary
- hide the featured image when viewing a single post

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a927ea5b4832297e402f52d1d9490