### PR TITLE
Move linked products to sidebar

### DIFF
--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -244,16 +244,6 @@
 {hook h="displayAfterEverComment"}
 {/if}
 {/if}
-{if isset($count_products) && $count_products > 0}
-<section id="products" class="mt-2">
-  <h2 class="text-center">{l s='Linked products' mod='everpsblog'}</h2>
-  <div class="products row">
-    {foreach from=$ps_products item="product"}
-      {include file="catalog/_partials/miniatures/product.tpl" product=$product}
-    {/foreach}
-  </div>
-</section>
-{/if}
 {if isset($related_posts) && $related_posts}
 <section id="related-posts" class="mt-2">
   <h2 class="text-center">{l s='Related posts' mod='everpsblog'}</h2>

--- a/views/templates/hook/columns.tpl
+++ b/views/templates/hook/columns.tpl
@@ -31,7 +31,8 @@
 </div>
 {/if}
 
-{if isset($ps_products) && $ps_products}
+{if isset($page.page_name) && $page.page_name == 'module-everpsblog-post'
+    && isset($ps_products) && $ps_products}
 <div class="columns_everblog_wrapper products_wrapper">
     <p class="text-uppercase h6 hidden-sm-down">{l s='Linked products' mod='everpsblog'}</p>
     <div class="products">


### PR DESCRIPTION
## Summary
- show linked products only when viewing a blog article

## Testing
- `bash tools/php_syntax_check.sh` *(fails: PHP executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a97982b808322ac3664703a4f936f