### PR TITLE
Add multi-language blog title

### DIFF
--- a/controllers/front/blog.php
+++ b/controllers/front/blog.php
@@ -156,6 +156,8 @@ class EverPsBlogblogModuleFrontController extends EverPsBlogModuleFrontControlle
         $everblog_bottom_text = $this->module::getConfigInMultipleLangs('EVERBLOG_BOTTOM_TEXT');
         $default_blog_bottom_text = $everblog_bottom_text[(int) Context::getContext()->language->id];
         // Bottom text is retrieved directly without shortcode parsing
+        $everblog_main_title = $this->module::getConfigInMultipleLangs('EVERBLOG_MAIN_TITLE');
+        $blog_page_title = $everblog_main_title[(int) Context::getContext()->language->id];
         Hook::exec('actionBeforeEverBlogInitContent', [
             'blog_post_number' => &$this->post_number,
             'starred' => &$starredPosts,
@@ -179,6 +181,7 @@ class EverPsBlogblogModuleFrontController extends EverPsBlogModuleFrontControlle
             'feed_url' => $feed_url,
             'default_blog_top_text' => $default_blog_top_text,
             'default_blog_bottom_text' => $default_blog_bottom_text,
+            'blog_page_title' => $blog_page_title,
             'paginated' => Tools::getValue('page'),
             'post_number' => (int) $this->post_number,
             'pagination' => $pagination,

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -164,6 +164,13 @@ class EverPsBlog extends Module
             && Configuration::updateValue('EVERPSBLOG_TAG_LAYOUT', 'layouts/layout-right-column.tpl')
             && Configuration::updateValue('EVERBLOG_SHOW_FEAT_POST', 1)
             && Configuration::updateValue('EVERBLOG_SITEMAP_NUMBER', 5000)
+            && Configuration::updateValue('EVERBLOG_MAIN_TITLE', (function () {
+                $title = [];
+                foreach (Language::getLanguages(false) as $language) {
+                    $title[$language['id_lang']] = 'Our blog';
+                }
+                return $title;
+            })())
             && $this->checkHooks()
             && $this->checkObligatoryHooks();
     }
@@ -851,6 +858,13 @@ class EverPsBlog extends Module
                         'Error : Blog bottom text is invalid'
                     );
                 }
+                if (Tools::getValue('EVERBLOG_MAIN_TITLE_'.$lang['id_lang'])
+                    && !Validate::isString(Tools::getValue('EVERBLOG_MAIN_TITLE_'.$lang['id_lang']))
+                ) {
+                    $this->postErrors[] = $this->l(
+                        'Error : Blog page title is invalid'
+                    );
+                }
             }
             // Layouts
             if (Tools::getValue('EVERPSBLOG_BLOG_LAYOUT')
@@ -977,6 +991,7 @@ class EverPsBlog extends Module
         $everblog_meta_desc = [];
         $everblog_top_text = [];
         $everblog_bottom_text = [];
+        $everblog_main_title = [];
         foreach (Language::getLanguages(false) as $lang) {
             $everblog_title[$lang['id_lang']] = (Tools::getValue(
                 'EVERBLOG_TITLE_'.$lang['id_lang']
@@ -997,6 +1012,11 @@ class EverPsBlog extends Module
                 'EVERBLOG_BOTTOM_TEXT_'.$lang['id_lang']
             )) ? Tools::getValue(
                 'EVERBLOG_BOTTOM_TEXT_'.$lang['id_lang']
+            ) : '';
+            $everblog_main_title[$lang['id_lang']] = (Tools::getValue(
+                'EVERBLOG_MAIN_TITLE_'.$lang['id_lang']
+            )) ? Tools::getValue(
+                'EVERBLOG_MAIN_TITLE_'.$lang['id_lang']
             ) : '';
         }
         // Save all datas
@@ -1021,6 +1041,12 @@ class EverPsBlog extends Module
                 Configuration::updateValue(
                     $key,
                     $everblog_bottom_text,
+                    true
+                );
+            } elseif ($key == 'EVERBLOG_MAIN_TITLE') {
+                Configuration::updateValue(
+                    $key,
+                    $everblog_main_title,
                     true
                 );
             } else {
@@ -1055,6 +1081,7 @@ class EverPsBlog extends Module
         $everblog_meta_desc = [];
         $everblog_top_text = [];
         $everblog_bottom_text = [];
+        $everblog_main_title = [];
         foreach (Language::getLanguages(false) as $lang) {
             $everblog_title[$lang['id_lang']] = (Tools::getValue(
                 'EVERBLOG_TITLE_'.$lang['id_lang']
@@ -1075,6 +1102,11 @@ class EverPsBlog extends Module
                 'EVERBLOG_BOTTOM_TEXT_'.$lang['id_lang']
             )) ? Tools::getValue(
                 'EVERBLOG_BOTTOM_TEXT_'.$lang['id_lang']
+            ) : '';
+            $everblog_main_title[$lang['id_lang']] = (Tools::getValue(
+                'EVERBLOG_MAIN_TITLE_'.$lang['id_lang']
+            )) ? Tools::getValue(
+                'EVERBLOG_MAIN_TITLE_'.$lang['id_lang']
             ) : '';
         }
         $formValues[] = [
@@ -1119,6 +1151,9 @@ class EverPsBlog extends Module
             ),
             'EVERBLOG_BOTTOM_TEXT' => static::getConfigInMultipleLangs(
                 'EVERBLOG_BOTTOM_TEXT'
+            ),
+            'EVERBLOG_MAIN_TITLE' => static::getConfigInMultipleLangs(
+                'EVERBLOG_MAIN_TITLE'
             ),
             'EVERPSBLOG_BLOG_LAYOUT' => Configuration::get('EVERPSBLOG_BLOG_LAYOUT'),
             'EVERPSBLOG_POST_LAYOUT' => Configuration::get('EVERPSBLOG_POST_LAYOUT'),
@@ -1543,6 +1578,14 @@ class EverPsBlog extends Module
                         'rows' => 4,
                         'lang' => true,
                         'autoload_rte' => true,
+                    ],
+                    [
+                        'type' => 'text',
+                        'label' => $this->l('Blog page title'),
+                        'name' => 'EVERBLOG_MAIN_TITLE',
+                        'desc' => $this->l('Main H1 title displayed on blog page'),
+                        'hint' => $this->l('Leave empty to use default translation'),
+                        'lang' => true,
                     ],
                     [
                         'type' => 'switch',

--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -68,7 +68,13 @@
 
 {block name="page_content"}
 <div class="d-flex align-items-center justify-content-between flex-wrap mb-3">
-    <h1 class="text-center flex-grow-1 m-0">{l s='Our blog' mod='everpsblog'}</h1>
+    <h1 class="text-center flex-grow-1 m-0">
+        {if isset($blog_page_title) && $blog_page_title}
+            {$blog_page_title|escape:'htmlall':'UTF-8'}
+        {else}
+            {l s='Our blog' mod='everpsblog'}
+        {/if}
+    </h1>
     <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search ms-3" data-doofinder-ignore="true">
         <div class="input-group">
             <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search by keywords' mod='everpsblog'}" required />


### PR DESCRIPTION
## Summary
- allow custom H1 title through new `EVERBLOG_MAIN_TITLE` setting
- expose setting in module configuration form
- display custom title on blog page

## Testing
- `php -l everpsblog.php` *(fails: command not found)*
- `npm test --silent`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f2a995c8322b7047bb450ee0977