### PR TITLE
Improve tag display

### DIFF
--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -450,6 +450,7 @@ class EverPsBlogpostModuleFrontController extends EverPsBlogModuleFrontControlle
                 'comments' => (array) $comments,
                 'commentsCount' => (int) $commentsCount,
                 'allow_views_count' => (bool) Configuration::get('EVERBLOG_SHOW_POST_COUNT'),
+                'show_post_tags' => (bool) Configuration::get('EVERBLOG_SHOW_POST_TAGS'),
                 'only_logged_comment' => (bool) Configuration::get('EVERBLOG_ONLY_LOGGED_COMMENT'),
             ]);
             if (Module::isInstalled('prettyblocks')

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -163,6 +163,7 @@ class EverPsBlog extends Module
             && Configuration::updateValue('EVERPSBLOG_AUTHOR_LAYOUT', 'layouts/layout-right-column.tpl')
             && Configuration::updateValue('EVERPSBLOG_TAG_LAYOUT', 'layouts/layout-right-column.tpl')
             && Configuration::updateValue('EVERBLOG_SHOW_FEAT_POST', 1)
+            && Configuration::updateValue('EVERBLOG_SHOW_POST_TAGS', 1)
             && Configuration::updateValue('EVERBLOG_SITEMAP_NUMBER', 5000)
             && Configuration::updateValue('EVERBLOG_MAIN_TITLE', (function () {
                 $title = [];
@@ -185,6 +186,7 @@ class EverPsBlog extends Module
             'id_module = ' . (int) $this->id
         );
         Configuration::deleteByName('EVERBLOG_CATEG_COLUMNS');
+        Configuration::deleteByName('EVERBLOG_SHOW_POST_TAGS');
         return parent::uninstall()
             && $this->uninstallModuleTab('AdminEverPsBlog')
             && $this->uninstallModuleTab('AdminEverPsBlogPost')
@@ -788,6 +790,13 @@ class EverPsBlog extends Module
                     'Error : The field "Show featured post image" is not valid'
                 );
             }
+            if (Tools::getValue('EVERBLOG_SHOW_POST_TAGS')
+                && !Validate::isBool(Tools::getValue('EVERBLOG_SHOW_POST_TAGS'))
+            ) {
+                $this->postErrors[] = $this->l(
+                    'Error : The field "Show tags on posts" is not valid'
+                );
+            }
             if (Tools::getValue('EVERBLOG_ARCHIVE_COLUMNS')
                 && !Validate::isBool(Tools::getValue('EVERBLOG_ARCHIVE_COLUMNS'))
             ) {
@@ -1136,6 +1145,7 @@ class EverPsBlog extends Module
             'EVERBLOG_SHOW_FEAT_CAT' => Configuration::get('EVERBLOG_SHOW_FEAT_CAT'),
             'EVERBLOG_SHOW_FEAT_TAG' => Configuration::get('EVERBLOG_SHOW_FEAT_TAG'),
             'EVERBLOG_SHOW_FEAT_POST' => Configuration::get('EVERBLOG_SHOW_FEAT_POST'),
+            'EVERBLOG_SHOW_POST_TAGS' => Configuration::get('EVERBLOG_SHOW_POST_TAGS'),
             'EVERBLOG_ARCHIVE_COLUMNS' => Configuration::get('EVERBLOG_ARCHIVE_COLUMNS'),
             'EVERBLOG_TAG_COLUMNS' => Configuration::get('EVERBLOG_TAG_COLUMNS'),
             'EVERBLOG_PRODUCT_COLUMNS' => Configuration::get('EVERBLOG_PRODUCT_COLUMNS'),
@@ -1377,6 +1387,27 @@ class EverPsBlog extends Module
                         'hint' => $this->l('Else will only be shown on admin'),
                         'required' => false,
                         'name' => 'EVERBLOG_SHOW_POST_COUNT',
+                        'is_bool' => true,
+                        'values' => [
+                            [
+                                'id' => 'active_on',
+                                'value' => 1,
+                                'label' => $this->l('Yes'),
+                            ],
+                            [
+                                'id' => 'active_off',
+                                'value' => 0,
+                                'label' => $this->l('No'),
+                            ],
+                        ],
+                    ],
+                    [
+                        'type' => 'switch',
+                        'label' => $this->l('Show tags on posts ?'),
+                        'desc' => $this->l('Display tags on post pages'),
+                        'hint' => $this->l('Set no to hide tags on posts'),
+                        'required' => false,
+                        'name' => 'EVERBLOG_SHOW_POST_TAGS',
                         'is_bool' => true,
                         'values' => [
                             [

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -131,12 +131,12 @@
             {if isset($allow_views_count) && $allow_views_count > 0}
             <span class="postviews"> | {$post->count|escape:'htmlall':'UTF-8'} {l s='Views' mod='everpsblog'}</span>
             {/if}
-            {if isset($tags) && $tags}
-            <p class="taggedIn d-none">{l s='Tagged in' mod='everpsblog'}
+            {if isset($show_post_tags) && $show_post_tags && isset($tags) && $tags}
+            <div class="post-tags">
             {foreach from=$tags item=tag}
-                <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag->id, 'link_rewrite'=>$tag->link_rewrite])|escape:'htmlall':'UTF-8'}" title="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">{$tag->title|escape:'htmlall':'UTF-8'}</a>&nbsp;
+                <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag->id, 'link_rewrite'=>$tag->link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge badge-info m-1" title="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">{$tag->title|escape:'htmlall':'UTF-8'}</a>
             {/foreach}
-            </p>
+            </div>
             {/if}
         </div>
             <div class="col-12 col-md-6">

--- a/views/templates/hook/columns.tpl
+++ b/views/templates/hook/columns.tpl
@@ -46,7 +46,7 @@
 <div class="columns_everblog_wrapper tag_wrapper">
     <p class="text-uppercase h6 hidden-sm-down">{l s='Tags from the blog' mod='everpsblog'}</p>
 {foreach from=$tags item=tag}
-    <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag.id_ever_tag, 'link_rewrite' => $tag.link_rewrite])|escape:'htmlall':'UTF-8'}" class="tag" title="{$tag.title|escape:'htmlall':'UTF-8'}">
+    <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag.id_ever_tag, 'link_rewrite' => $tag.link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge badge-info m-1 tag" title="{$tag.title|escape:'htmlall':'UTF-8'}">
         {$tag.title|escape:'htmlall':'UTF-8'}
     </a>
 {/foreach}


### PR DESCRIPTION
## Summary
- add switch to show tags on posts
- add new configuration defaults
- improve tag display on post page
- enhance tag display in sidebar

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852483938c48322b114c07c14df9cae