### PR TITLE
Add product shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ You can use a module like **Ever Block** to insert content on these hooks.
 ### Shortcodes
 - `[everpsblog category="ID" limit="X" order="asc|desc"]` displays posts from a specific category.
 - `[everpsblog latest="X"]` shows the latest blog posts.
+- `[everpsblog product="ID" orderby="FIELD" orderway="asc|desc" limit="X"]` lists posts linked to a product.
 
 ### Documentation
 A detailed guide in French is available at <https://www.team-ever.com/prestashop-1-7-un-module-de-blog-gratuit/>. You can also [support the project with a donation](https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE).
@@ -85,6 +86,7 @@ Le module **Ever Block** peut être utilisé pour ajouter du contenu sur ces hoo
 ### Shortcodes
 - `[everpsblog category="ID" limit="X" order="asc|desc"]` affiche les articles d'une catégorie.
 - `[everpsblog latest="X"]` affiche les derniers articles du blog.
+- `[everpsblog product="ID" orderby="CHAMP" orderway="asc|desc" limit="X"]` liste les articles liés à un produit.
 
 ### Documentation
 Un guide complet est disponible en français à l’adresse suivante : <https://www.team-ever.com/prestashop-1-7-un-module-de-blog-gratuit/>. Vous pouvez aussi [soutenir le projet par un don](https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE).
@@ -128,6 +130,7 @@ Puedes usar un módulo como **Ever Block** para insertar contenido en estos hook
 ### Shortcodes
 - `[everpsblog category="ID" limit="X" order="asc|desc"]` muestra las entradas de una categoría.
 - `[everpsblog latest="X"]` muestra las últimas entradas del blog.
+- `[everpsblog product="ID" orderby="CAMPO" orderway="asc|desc" limit="X"]` lista las entradas vinculadas a un producto.
 
 ### Documentación
 Hay una guía detallada en francés disponible en <https://www.team-ever.com/prestashop-1-7-un-module-de-blog-gratuit/>. También puedes [apoyar el proyecto con una donación](https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE).
@@ -171,6 +174,7 @@ Ever PS Blog è un modulo gratuito e multilingue che aggiunge un blog completo a
 ### Shortcodes
 - `[everpsblog category="ID" limit="X" order="asc|desc"]` mostra gli articoli di una categoria.
 - `[everpsblog latest="X"]` mostra gli ultimi articoli del blog.
+- `[everpsblog product="ID" orderby="CAMPO" orderway="asc|desc" limit="X"]` elenca gli articoli collegati a un prodotto.
 
 ### Documentazione
 È disponibile una guida dettagliata in francese su <https://www.team-ever.com/prestashop-1-7-un-module-de-blog-gratuit/>. Puoi anche [sostenere il progetto con una donazione](https://www.paypal.com/donate?hosted_button_id=3CM3XREMKTMSE).

--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -942,7 +942,9 @@ class EverPsBlogPost extends ObjectModel
         $id_product,
         $start = 0,
         $limit = null,
-        $post_status = 'published'
+        $post_status = 'published',
+        $orderBy = 'date_add',
+        $orderWay = 'DESC'
     ) {
         $cache_id = 'EverPsBlogPost::getPostsByProduct_'
         . (int) $id_lang
@@ -955,7 +957,11 @@ class EverPsBlogPost extends ObjectModel
         . '_'
         . (int) $limit
         . '_'
-        . $post_status;
+        . $post_status
+        . '_'
+        . pSQL($orderBy)
+        . '_'
+        . pSQL($orderWay);
         if (!Cache::isStored($cache_id)) {
             $context = Context::getContext();
             if ((int) $limit <= 0) {
@@ -978,7 +984,7 @@ class EverPsBlogPost extends ObjectModel
             $sql->where('bp.id_shop = ' . (int) $id_shop);
             $sql->where('bpl.id_lang = ' . (int) $id_lang);
             $sql->where('bpp.' . self::$definition['primary'] . '_product = ' . (int) $id_product);
-            $sql->orderBy('bp.date_add DESC');
+            $sql->orderBy('bp.' . pSQL($orderBy) . ' ' . pSQL($orderWay));
             $sql->limit((int) $limit, (int) $start);
             $posts = Db::getInstance()->executeS($sql);
             $return = [];

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -4423,6 +4423,13 @@ class EverPsBlog extends Module
                 return $this->renderLatestPostsShortcode($limit);
             }
 
+            if (isset($attrs['product'])) {
+                $limit = isset($attrs['limit']) ? (int) $attrs['limit'] : null;
+                $orderBy = isset($attrs['orderby']) ? $attrs['orderby'] : 'date_add';
+                $orderWay = isset($attrs['orderway']) ? strtoupper($attrs['orderway']) : 'DESC';
+                return $this->renderProductPostsShortcode((int) $attrs['product'], $orderBy, $orderWay, $limit);
+            }
+
             return '';
         }, $html);
     }
@@ -4458,6 +4465,39 @@ class EverPsBlog extends Module
             (int) $this->context->shop->id,
             0,
             $limit
+        );
+        if (!$posts) {
+            return '';
+        }
+        $this->context->smarty->assign([
+            'posts' => $posts,
+            'blogcolor' => Configuration::get('EVERBLOG_CSS_FILE'),
+        ]);
+        return $this->display(__FILE__, 'views/templates/hook/shortcode.tpl');
+    }
+
+    /**
+     * Render posts associated with a product
+     *
+     * @param int $product  Product ID
+     * @param string $orderBy Field used for ordering
+     * @param string $orderWay Order direction ASC|DESC
+     * @param int|null $limit Maximum number of posts
+     *
+     * @return string
+     */
+    private function renderProductPostsShortcode($product, $orderBy, $orderWay, $limit = null)
+    {
+        $orderWay = strtoupper($orderWay) === 'ASC' ? 'ASC' : 'DESC';
+        $posts = EverPsBlogPost::getPostsByProduct(
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id,
+            (int) $product,
+            0,
+            $limit,
+            'published',
+            $orderBy,
+            $orderWay
         );
         if (!$posts) {
             return '';


### PR DESCRIPTION
## Summary
- add order parameters to `getPostsByProduct`
- support `[everpsblog product]` shortcode with optional limit
- document the new shortcode in all README languages
- allow optional limit in `renderProductPostsShortcode`

## Testing
- ❌ `php -l everpsblog.php` (failed to run because `php` was not found)
- ❌ `php -l classes/EverPsBlogPost.php` (failed to run because `php` was not found)

------
https://chatgpt.com/codex/tasks/task_e_685249347ce483228893c328fa2720bc