### PR TITLE
Show post default category

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -1057,11 +1057,14 @@ class AdminEverPsBlogPostController extends ModuleAdminController
                 $post->id_author = Tools::getValue('id_author');
             }
             // Categories, products and tags
-            // Default category is fully required
+            // Default category is fully required and cannot be root
+            $rootCategory = EverPsBlogCategory::getRootCategory();
             if (!Tools::getValue('id_default_category')
                 || !Validate::isInt(Tools::getValue('id_default_category'))
             ) {
-                $post->id_parent_category = $this->unclassedCategory;
+                $this->errors[] = $this->l('Default category is required');
+            } elseif ((int) Tools::getValue('id_default_category') == (int) $rootCategory->id) {
+                $this->errors[] = $this->l('Default category cannot be the root category');
             } else {
                 $post->id_default_category = Tools::getValue('id_default_category');
             }

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -35,6 +35,7 @@ class EverPsBlogpostModuleFrontController extends EverPsBlogModuleFrontControlle
     protected $post;
     protected $blog;
     protected $author;
+    protected $default_category;
     public $controller_name = 'post';
 
     public function init()
@@ -72,6 +73,7 @@ class EverPsBlogpostModuleFrontController extends EverPsBlogModuleFrontControlle
                 Tools::redirect('index.php?controller=404');
             }
         }
+        $this->default_category = $defaultCategory;
         if (isset($this->post->allowed_groups) && $this->post->allowed_groups) {
             if (is_array($this->post->allowed_groups)) {
                 $allowedGroups = [];
@@ -435,6 +437,7 @@ class EverPsBlogpostModuleFrontController extends EverPsBlogModuleFrontControlle
                 'show_featured_post' => false,
                 'author_cover' => $this->author_cover,
                 'author' => $this->author,
+                'default_category' => $this->default_category,
                 'social_share_links' => $social_share_links,
                 'count_products' => $count_products,
                 'post' => $this->post,

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -89,6 +89,9 @@
         <h1 class="text-start">{$post->title|escape:'htmlall':'UTF-8'}</h1>
         <p class="postpublished text-start">
             <strong>{$post->date_add|date_format:'%d %B %Y'|escape:'htmlall':'UTF-8'}</strong>
+            {if isset($default_category) && $default_category && !$default_category->is_root_category}
+                - <a href="{$link->getModuleLink('everpsblog', 'category', ['id_ever_category'=>$default_category->id_ever_category, 'link_rewrite'=>$default_category->link_rewrite])|escape:'htmlall':'UTF-8'}" title="{$default_category->title|escape:'htmlall':'UTF-8'}">{$default_category->title|escape:'htmlall':'UTF-8'}</a>
+            {/if}
         </p>
         {if isset($show_author) && $show_author}
         <p class="text-center author_cover_container">


### PR DESCRIPTION
## Summary
- enforce that a post cannot use the root category as default
- expose default category to post templates
- show the post default category next to the publication date

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525bf2d0c483229f7c9389f995fd7d