### PR TITLE
Reduce blog thumbnail sizes

### DIFF
--- a/classes/EverPsBlogImage.php
+++ b/classes/EverPsBlogImage.php
@@ -206,6 +206,48 @@ class EverPsBlogImage extends ObjectModel
     }
 
     /**
+     * Get resized blog image link
+     * @param int $id_element
+     * @param int $id_shop
+     * @param string $image_type
+     * @param int $width
+     * @param int $height
+     * @return string image link
+     */
+    public static function getBlogThumbUrl($id_element, $id_shop, $image_type, $width = 320, $height = 180)
+    {
+        $cache_id = 'EverPsBlogImage::getBlogThumbUrl_'
+        . (int) $id_element
+        . '_' . (int) $id_shop
+        . '_' . $image_type
+        . '_' . (int) $width
+        . 'x' . (int) $height;
+        if (!Cache::isStored($cache_id)) {
+            $original = _PS_IMG_DIR_ . $image_type . '/' . (int) $id_element . '.jpg';
+            if (!file_exists($original)) {
+                $return = self::getBlogImageUrl($id_element, $id_shop, $image_type);
+                Cache::store($cache_id, $return);
+                return $return;
+            }
+            $thumbDir = _PS_IMG_DIR_ . $image_type . '/thumbs/';
+            if (!file_exists($thumbDir)) {
+                @mkdir($thumbDir, 0755, true);
+            }
+            $thumbFile = $thumbDir . (int) $id_element . '-' . (int) $width . 'x' . (int) $height . '.jpg';
+            if (!file_exists($thumbFile)) {
+                ImageManager::resize($original, $thumbFile, (int) $width, (int) $height);
+            }
+            $return = Tools::getHttpHost(true)
+            . __PS_BASE_URI__
+            . 'img/' . $image_type . '/thumbs/'
+            . (int) $id_element . '-' . (int) $width . 'x' . (int) $height . '.jpg';
+            Cache::store($cache_id, $return);
+            return $return;
+        }
+        return Cache::retrieve($cache_id);
+    }
+
+    /**
      * Check if image exists on PS folder
      * @param int id_element, string image_type
      * @return bool file exists or not

--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -305,6 +305,11 @@ class EverPsBlogPost extends ObjectModel
                         (int) $id_shop,
                         'post'
                     );
+                    $post['featured_thumb'] = EverPsBlogImage::getBlogThumbUrl(
+                        (int) $post[self::$definition['primary']],
+                        (int) $id_shop,
+                        'post'
+                    );
                     $return[] = $post;
                 }
             } else {
@@ -424,6 +429,11 @@ class EverPsBlogPost extends ObjectModel
                     (int) Configuration::get('EVERPSBLOG_EXCERPT')
                 );
                 $post->featured_image = EverPsBlogImage::getBlogImageUrl(
+                    (int) $post->id,
+                    (int) $id_shop,
+                    'post'
+                );
+                $post->featured_thumb = EverPsBlogImage::getBlogThumbUrl(
                     (int) $post->id,
                     (int) $id_shop,
                     'post'
@@ -677,6 +687,11 @@ class EverPsBlogPost extends ObjectModel
                     (int) $id_shop,
                     'post'
                 );
+                $post->featured_thumb = EverPsBlogImage::getBlogThumbUrl(
+                    (int) $post->id,
+                    (int) $id_shop,
+                    'post'
+                );
                 $return[] = $post;
             }
             if ($return) {
@@ -804,6 +819,11 @@ class EverPsBlogPost extends ObjectModel
                     (int) $id_shop,
                     'post'
                 );
+                $post->featured_thumb = EverPsBlogImage::getBlogThumbUrl(
+                    (int) $post->id,
+                    (int) $id_shop,
+                    'post'
+                );
                 $return[] = $post;
             }
             if ($return) {
@@ -921,6 +941,11 @@ class EverPsBlogPost extends ObjectModel
                     (int) $id_shop,
                     'post'
                 );
+                $post->featured_thumb = EverPsBlogImage::getBlogThumbUrl(
+                    (int) $post->id,
+                    (int) $id_shop,
+                    'post'
+                );
                 $return[] = $post;
             }
             if ($return) {
@@ -1033,6 +1058,11 @@ class EverPsBlogPost extends ObjectModel
                     (int) Configuration::get('EVERPSBLOG_EXCERPT')
                 );
                 $post->featured_image = EverPsBlogImage::getBlogImageUrl(
+                    (int) $post->id,
+                    (int) $id_shop,
+                    'post'
+                );
+                $post->featured_thumb = EverPsBlogImage::getBlogThumbUrl(
                     (int) $post->id,
                     (int) $id_shop,
                     'post'

--- a/views/templates/front/loop/post_array.tpl
+++ b/views/templates/front/loop/post_array.tpl
@@ -18,7 +18,7 @@
     <article class="col-6 col-md-4 mb-4 article everpsblog" id="everpsblog-{$item.id_ever_post|escape:'htmlall':'UTF-8'}">
         <div class="article-img text-center mb-2">
             {if isset($show_featured_post) && $show_featured_post}
-            <img src="{$item.featured_image|escape:'htmlall':'UTF-8'}" class="img-fluid w-100 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item.title|escape:'htmlall':'UTF-8'} {$shop.name|escape:htmlall:'UTF-8'}" title="{$item.title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" />
+            <img src="{$item.featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img-fluid w-100 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item.title|escape:'htmlall':'UTF-8'} {$shop.name|escape:htmlall:'UTF-8'}" title="{$item.title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" />
             {/if}
         </div>
         <h3 class="everpsblog article-content" id="everpsblog-post-title-{$item.id_ever_post|escape:'htmlall':'UTF-8'}">

--- a/views/templates/front/loop/post_object.tpl
+++ b/views/templates/front/loop/post_object.tpl
@@ -18,7 +18,7 @@
     <div class="col-6 col-md-4 mb-4 article everpsblog" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
         <div class="article-img text-center mb-2">
             {if isset($show_featured_post) && $show_featured_post}
-            <img src="{$item->featured_image|escape:'htmlall':'UTF-8'}" class="img-fluid w-100 mx-auto d-block {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" />
+            <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img-fluid w-100 mx-auto d-block {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}" />
             {/if}
         </div>
         <h3 class="everpsblog article-content" id="everpsblog-post-title-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">

--- a/views/templates/front/loop/post_product.tpl
+++ b/views/templates/front/loop/post_product.tpl
@@ -18,7 +18,7 @@
         <div class="col-12 col-md-3 article everpsblog mb-3" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
                 <div class="col-12 article-img">
                     {if isset($show_featured_post) && $show_featured_post}
-                    <img src="{$item->featured_image|escape:'htmlall':'UTF-8'}" class="img img-fluid {if $animated}animated flipSideBySide zoomed{/if}" title="{$item->title|escape:'htmlall':'UTF-8'}" alt="{$item->title|escape:'htmlall':'UTF-8'}"/>
+                    <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img img-fluid {if $animated}animated flipSideBySide zoomed{/if}" title="{$item->title|escape:'htmlall':'UTF-8'}" alt="{$item->title|escape:'htmlall':'UTF-8'}"/>
                     {/if}
                 </div>
                 <div class="col-12 col-12">

--- a/views/templates/hook/home.tpl
+++ b/views/templates/hook/home.tpl
@@ -30,7 +30,7 @@
             <div class="col-12 col-md-3 article everpsblog" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
                     <div class="col-12 article-img {$blogcolor|escape:'htmlall':'UTF-8'}">
                         {if isset($show_featured_post) && $show_featured_post}
-                        <img src="{$item->featured_image|escape:'htmlall':'UTF-8'}" class="img-fluid col-12 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" />
+                        <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img-fluid col-12 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" />
                         {/if}
                     </div>
                     <div class="col-12 col-12">

--- a/views/templates/hook/shortcode.tpl
+++ b/views/templates/hook/shortcode.tpl
@@ -3,7 +3,7 @@
     <div class="col-12 col-md-4 article everpsblog mb-3" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
         <div class="col-12 article-img">
             {if isset($show_featured_post) && $show_featured_post}
-            <img src="{$item->featured_image|escape:'htmlall':'UTF-8'}" class="img img-fluid" alt="{$item->title|escape:'htmlall':'UTF-8'}" />
+            <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img img-fluid" alt="{$item->title|escape:'htmlall':'UTF-8'}" />
             {/if}
         </div>
         <div class="col-12">


### PR DESCRIPTION
## Summary
- generate blog thumbnails via `getBlogThumbUrl`
- expose thumb URLs in post objects
- use 320x180 thumbnails with width/height attributes in templates

## Testing
- `bash tools/php_syntax_check.sh` *(fails: PHP executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526c0ba7688322b2e61acfd3c01fa7