### PR TITLE
Add htaccess to block direct PHP access

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,23 @@
+# Prevent direct access to PHP files except index.php
+<FilesMatch "\.php$">
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order deny,allow
+        Deny from all
+    </IfModule>
+</FilesMatch>
+
+<Files "index.php">
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+    </IfModule>
+</Files>
+
+# Disable directory listing
+Options -Indexes


### PR DESCRIPTION
## Summary
- add `.htaccess` to block direct access to PHP files and disable directory listing

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853999be4ac83229ddc1b98e019f82a