### PR TITLE
Fix default category inclusion on post save

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -1060,7 +1060,7 @@ class AdminEverPsBlogPostController extends ModuleAdminController
             // Default category is fully required and cannot be root
             $rootCategory = EverPsBlogCategory::getRootCategory();
             if (!Tools::getValue('id_default_category')
-                || !Validate::isInt(Tools::getValue('id_default_category'))
+                || !Validate::isUnsignedInt(Tools::getValue('id_default_category'))
             ) {
                 $this->errors[] = $this->l('Default category is required');
             } elseif ((int) Tools::getValue('id_default_category') == (int) $rootCategory->id) {
@@ -1073,7 +1073,7 @@ class AdminEverPsBlogPostController extends ModuleAdminController
                 $post_categories = [$post_categories];
             }
             if (!in_array(Tools::getValue('id_default_category'), $post_categories)) {
-                $post_categories[] = $this->unclassedCategory;
+                $post_categories[] = (int) Tools::getValue('id_default_category');
             }
             $post->post_categories = json_encode($post_categories);
             $post->allowed_groups = json_encode(Tools::getValue('allowed_groups'));


### PR DESCRIPTION
## Summary
- ensure default category is validated as an unsigned integer
- automatically add the selected default category to the category list if missing

## Testing
- `php -l controllers/admin/AdminEverpsBlogPostController.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68539ae6ac1c8322bcc618334f0b3e1b