### PR TITLE
Fix multishop filtering for blog categories

### DIFF
--- a/classes/EverPsBlogCategory.php
+++ b/classes/EverPsBlogCategory.php
@@ -252,7 +252,7 @@ class EverPsBlogCategory extends ObjectModel
                 'bc',
                 'bc.' . self::$definition['primary'] . ' = bcl.' . self::$definition['primary']
             );
-            $sql->leftJoin(
+            $sql->innerJoin(
                 self::$definition['table'] . '_shop',
                 'bcs',
                 'bc.' . self::$definition['primary'] . ' = bcs.' . self::$definition['primary']
@@ -334,7 +334,7 @@ class EverPsBlogCategory extends ObjectModel
                 'bc',
                 'bc.' . self::$definition['primary'] . ' = bcl.' . self::$definition['primary']
             );
-            $sql->leftJoin(
+            $sql->innerJoin(
                 self::$definition['table'] . '_shop',
                 'bcs',
                 'bc.' . self::$definition['primary'] . ' = bcs.' . self::$definition['primary']
@@ -387,7 +387,7 @@ class EverPsBlogCategory extends ObjectModel
                 'bc',
                 'bc.' . self::$definition['primary'] . ' = bcl.' . self::$definition['primary']
             );
-            $sql->leftJoin(
+            $sql->innerJoin(
                 self::$definition['table'] . '_shop',
                 'bcs',
                 'bc.' . self::$definition['primary'] . ' = bcs.' . self::$definition['primary']


### PR DESCRIPTION
## Summary
- ensure blog categories are restricted to the current shop

## Testing
- `php -l classes/EverPsBlogCategory.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a0bb31608322975a9586e62d2336