### PR TITLE
Refactor admin controllers

### DIFF
--- a/controllers/admin/AdminEverpsBlogCommentController.php
+++ b/controllers/admin/AdminEverpsBlogCommentController.php
@@ -27,19 +27,16 @@ require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogTag.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogComment.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogImage.php';
 
-class AdminEverPsBlogCommentController extends ModuleAdminController
+class AdminEverPsBlogCommentController extends EverPsBlogAdminController
 {
     private $html;
 
     public function __construct()
     {
         $this->isSeven = Tools::version_compare(_PS_VERSION_, '1.7', '>=') ? true : false;
-        $this->bootstrap = true;
         $this->display = $this->l('Ever Blog Comments');
         $this->table = 'ever_blog_comments';
         $this->className = 'EverPsBlogComment';
-        $this->module_name = 'everpsblog';
-        $this->context = Context::getContext();
         $this->identifier = "id_ever_comment";
         $this->_orderBy = 'id_ever_comment';
         $this->_orderWay = 'DESC';
@@ -84,72 +81,6 @@ class AdminEverPsBlogCommentController extends ModuleAdminController
         );
 
         $this->colorOnBackground = true;
-        $moduleConfUrl  = 'index.php?controller=AdminModules&configure=everpsblog&token=';
-        $moduleConfUrl .= Tools::getAdminTokenLite('AdminModules');
-        $postUrl  = 'index.php?controller=AdminEverPsBlogPost&token=';
-        $postUrl .= Tools::getAdminTokenLite('AdminEverPsBlogPost');
-        $authorUrl  = 'index.php?controller=AdminEverPsBlogAuthor&token=';
-        $authorUrl .= Tools::getAdminTokenLite('AdminEverPsBlogAuthor');
-        $categoryUrl  = 'index.php?controller=AdminEverPsBlogCategory&token=';
-        $categoryUrl .= Tools::getAdminTokenLite('AdminEverPsBlogCategory');
-        $tagUrl  = 'index.php?controller=AdminEverPsBlogTag&token=';
-        $tagUrl .= Tools::getAdminTokenLite('AdminEverPsBlogTag');
-        $commentUrl  = 'index.php?controller=AdminEverPsBlogComment&token=';
-        $commentUrl .= Tools::getAdminTokenLite('AdminEverPsBlogComment');
-        $blogUrl = Context::getContext()->link->getModuleLink(
-            'everpsblog',
-            'blog',
-            [],
-            true
-        );
-        $ever_blog_token = Tools::encrypt('everpsblog/cron');
-        $emptytrash = $this->context->link->getModuleLink(
-            $this->module_name,
-            'emptytrash',
-            array(
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id
-            ),
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $pending = $this->context->link->getModuleLink(
-            $this->module_name,
-            'pending',
-            array(
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id
-            ),
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $planned = $this->context->link->getModuleLink(
-            $this->module_name,
-            'planned',
-            array(
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id
-            ),
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $this->context->smarty->assign(array(
-            'image_dir' => Tools::getHttpHost(true) . __PS_BASE_URI__.'/modules/everpsblog/views/img/',
-            'everpsblogcron' => $emptytrash,
-            'everpsblogcronpending' => $pending,
-            'everpsblogcronplanned' => $planned,
-            'moduleConfUrl' => $moduleConfUrl,
-            'authorUrl' => $authorUrl,
-            'postUrl' => $postUrl,
-            'categoryUrl' => $categoryUrl,
-            'tagUrl' => $tagUrl,
-            'commentUrl' => $commentUrl,
-            'blogUrl' => $blogUrl,
-        ));
-
         parent::__construct();
     }
 
@@ -179,12 +110,12 @@ class AdminEverPsBlogCommentController extends ModuleAdminController
         $this->addRowAction('deleteComment');
         $this->addRowAction('ViewPost');
         $this->toolbar_title = $this->l('Comment settings');
-        $this->bulk_actions = array(
-            'delete' => array(
+        $this->bulk_actions = [
+            'delete' => [
                 'text' => $this->l('Delete selected items'),
-                'confirm' => $this->l('Delete selected items ?')
-            ),
-        );
+                'confirm' => $this->l('Delete selected items ?'),
+            ],
+        ];
 
         if (Tools::getIsset('deleteComment'.$this->table)) {
             $everObj = new EverPsBlogComment(
@@ -205,28 +136,7 @@ class AdminEverPsBlogCommentController extends ModuleAdminController
             $this->processBulkEnable();
         }
 
-        $lists = parent::renderList();
-
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            .'/everpsblog/views/templates/admin/headerController.tpl'
-        );
-        $blog_instance = Module::getInstanceByName($this->module_name);
-        if ($blog_instance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_
-                .'/'
-                .$this->module_name
-                .'/views/templates/admin/upgrade.tpl'
-            );
-        }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            .'/everpsblog/views/templates/admin/footer.tpl'
-        );
-
-        return $this->html;
+        return parent::renderList();
     }
 
     public function renderForm()

--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -30,7 +30,7 @@ require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogTaxonomy.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogImage.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogCleaner.php';
 
-class AdminEverPsBlogPostController extends ModuleAdminController
+class AdminEverPsBlogPostController extends EverPsBlogAdminController
 {
     private $html;
     public $name;
@@ -38,13 +38,9 @@ class AdminEverPsBlogPostController extends ModuleAdminController
     public function __construct()
     {
         $this->name = 'AdminEverPsBlogPostController';
-        $this->bootstrap = true;
         $this->display = $this->l('Ever Blog Posts');
         $this->table = 'ever_blog_post';
         $this->className = 'EverPsBlogPost';
-        $this->shop_url = Tools::getHttpHost(true) . __PS_BASE_URI__;
-        $this->img_url = $this->shop_url . 'modules/everpsblog/views/img/';
-        $this->context = Context::getContext();
         $this->identifier = 'id_ever_post';
         $this->_orderBy = $this->identifier;
         $this->_orderWay = 'DESC';
@@ -153,71 +149,6 @@ class AdminEverPsBlogPostController extends ModuleAdminController
                 )';
         $this->_where = 'AND a.id_shop = ' . (int) $this->context->shop->id;
         $this->_where = 'AND l.id_lang = ' . (int) $this->context->language->id;
-        $moduleConfUrl  = 'index.php?controller=AdminModules&configure=everpsblog&token=';
-        $moduleConfUrl .= Tools::getAdminTokenLite('AdminModules');
-        $postUrl  = 'index.php?controller=AdminEverPsBlogPost&token=';
-        $postUrl .= Tools::getAdminTokenLite('AdminEverPsBlogPost');
-        $authorUrl  = 'index.php?controller=AdminEverPsBlogAuthor&token=';
-        $authorUrl .= Tools::getAdminTokenLite('AdminEverPsBlogAuthor');
-        $categoryUrl  = 'index.php?controller=AdminEverPsBlogCategory&token=';
-        $categoryUrl .= Tools::getAdminTokenLite('AdminEverPsBlogCategory');
-        $tagUrl  = 'index.php?controller=AdminEverPsBlogTag&token=';
-        $tagUrl .= Tools::getAdminTokenLite('AdminEverPsBlogTag');
-        $commentUrl  = 'index.php?controller=AdminEverPsBlogComment&token=';
-        $commentUrl .= Tools::getAdminTokenLite('AdminEverPsBlogComment');
-        $blogUrl = $this->context->link->getModuleLink(
-            'everpsblog',
-            'blog',
-            [],
-            true
-        );
-        $ever_blog_token = Tools::encrypt('everpsblog/cron');
-        $emptytrash = $this->context->link->getModuleLink(
-            'everpsblog',
-            'emptytrash',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $pending = $this->context->link->getModuleLink(
-            'everpsblog',
-            'pending',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $planned = $this->context->link->getModuleLink(
-            'everpsblog',
-            'planned',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $this->context->smarty->assign([
-            'image_dir' => Tools::getHttpHost(true) . __PS_BASE_URI__ . '/modules/everpsblog/views/img/',
-            'everpsblogcron' => $emptytrash,
-            'everpsblogcronpending' => $pending,
-            'everpsblogcronplanned' => $planned,
-            'moduleConfUrl' => $moduleConfUrl,
-            'authorUrl' => $authorUrl,
-            'postUrl' => $postUrl,
-            'categoryUrl' => $categoryUrl,
-            'tagUrl' => $tagUrl,
-            'commentUrl' => $commentUrl,
-            'blogUrl' => $blogUrl,
-        ]);
         parent::__construct();
     }
 

--- a/controllers/admin/AdminEverpsBlogTagController.php
+++ b/controllers/admin/AdminEverpsBlogTagController.php
@@ -27,21 +27,16 @@ require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogTag.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogComment.php';
 require_once _PS_MODULE_DIR_ . 'everpsblog/classes/EverPsBlogImage.php';
 
-class AdminEverPsBlogTagController extends ModuleAdminController
+class AdminEverPsBlogTagController extends EverPsBlogAdminController
 {
     private $html;
 
     public function __construct()
     {
         $this->name = 'AdminEverPsBlogTagController';
-        $this->bootstrap = true;
         $this->display = $this->l('Ever Blog Tags');
         $this->table = 'ever_blog_tag';
         $this->className = 'EverPsBlogTag';
-        $this->module_name = 'everpsblog';
-        $this->shop_url = Tools::getHttpHost(true) . __PS_BASE_URI__;
-        $this->img_url = $this->shop_url.'modules/'.$this->module_name.'/views/img/';
-        $this->context = Context::getContext();
         $this->identifier = 'id_ever_tag';
         $this->_orderBy = $this->identifier;
         $this->_orderWay = 'DESC';
@@ -63,6 +58,12 @@ class AdminEverPsBlogTagController extends ModuleAdminController
             'title' => [
                 'title' => $this->l('Tag title'),
                 'align' => 'left',
+            ],
+            'posts_count' => [
+                'title' => $this->l('Posts'),
+                'align' => 'center',
+                'orderby' => false,
+                'filter' => false,
             ],
             'indexable' => [
                 'title' => $this->l('Index'),
@@ -99,7 +100,9 @@ class AdminEverPsBlogTagController extends ModuleAdminController
         );
 
         $this->colorOnBackground = true;
-        $this->_select = 'l.title, CONCAT("' . $this->img_url . '",ai.image_link) AS featured_img';
+        $this->_select = 'l.title,
+        (SELECT COUNT(*) FROM `'._DB_PREFIX_.'ever_blog_post_tag` pt WHERE pt.id_ever_post_tag = a.id_ever_tag) AS posts_count,
+        CONCAT("' . $this->img_url . '",ai.image_link) AS featured_img';
 
         $this->_join =
             'LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_tag_lang` l
@@ -113,71 +116,6 @@ class AdminEverPsBlogTagController extends ModuleAdminController
                 )';
         $this->_where = 'AND a.id_shop = ' . (int) $this->context->shop->id;
         $this->_where = 'AND l.id_lang = ' . (int) $this->context->language->id;
-        $moduleConfUrl  = 'index.php?controller=AdminModules&configure=everpsblog&token=';
-        $moduleConfUrl .= Tools::getAdminTokenLite('AdminModules');
-        $postUrl  = 'index.php?controller=AdminEverPsBlogPost&token=';
-        $postUrl .= Tools::getAdminTokenLite('AdminEverPsBlogPost');
-        $authorUrl  = 'index.php?controller=AdminEverPsBlogAuthor&token=';
-        $authorUrl .= Tools::getAdminTokenLite('AdminEverPsBlogAuthor');
-        $categoryUrl  = 'index.php?controller=AdminEverPsBlogCategory&token=';
-        $categoryUrl .= Tools::getAdminTokenLite('AdminEverPsBlogCategory');
-        $tagUrl  = 'index.php?controller=AdminEverPsBlogTag&token=';
-        $tagUrl .= Tools::getAdminTokenLite('AdminEverPsBlogTag');
-        $commentUrl  = 'index.php?controller=AdminEverPsBlogComment&token=';
-        $commentUrl .= Tools::getAdminTokenLite('AdminEverPsBlogComment');
-        $blogUrl = Context::getContext()->link->getModuleLink(
-            'everpsblog',
-            'blog',
-            [],
-            true
-        );
-        $ever_blog_token = Tools::encrypt('everpsblog/cron');
-        $emptytrash = $this->context->link->getModuleLink(
-            $this->module_name,
-            'emptytrash',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $pending = $this->context->link->getModuleLink(
-            $this->module_name,
-            'pending',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $planned = $this->context->link->getModuleLink(
-            $this->module_name,
-            'planned',
-            [
-                'token' => $ever_blog_token,
-                'id_shop' => (int) $this->context->shop->id,
-            ],
-            true,
-            (int) $this->context->language->id,
-            (int) $this->context->shop->id
-        );
-        $this->context->smarty->assign([
-            'image_dir' => Tools::getHttpHost(true) . __PS_BASE_URI__ . '/modules/everpsblog/views/img/',
-            'everpsblogcron' => $emptytrash,
-            'everpsblogcronpending' => $pending,
-            'everpsblogcronplanned' => $planned,
-            'moduleConfUrl' => $moduleConfUrl,
-            'authorUrl' => $authorUrl,
-            'postUrl' => $postUrl,
-            'categoryUrl' => $categoryUrl,
-            'tagUrl' => $tagUrl,
-            'commentUrl' => $commentUrl,
-            'blogUrl' => $blogUrl,
-        ]);
 
         parent::__construct();
     }
@@ -224,37 +162,7 @@ class AdminEverPsBlogTagController extends ModuleAdminController
             $this->processBulkEnable();
         }
 
-        $lists = parent::renderList();
-
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            . '/'
-            . $this->module_name
-            . '/views/templates/admin/headerController.tpl'
-        );
-        $blog_instance = Module::getInstanceByName($this->module_name);
-        if ($blog_instance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_
-                . '/'
-                . $this->module_name
-                . '/views/templates/admin/upgrade.tpl'
-            );
-        }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            . '/'
-            . $this->module_name
-        );
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            . '/'
-            . $this->module_name
-            . '/views/templates/admin/footer.tpl'
-        );
-
-        return $this->html;
+        return parent::renderList();
     }
 
     protected function getConfigFormValues($obj)

--- a/controllers/admin/EverPsBlogAdminController.php
+++ b/controllers/admin/EverPsBlogAdminController.php
@@ -1,0 +1,135 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+abstract class EverPsBlogAdminController extends ModuleAdminController
+{
+    protected $module_name = 'everpsblog';
+    protected $shop_url;
+    protected $img_url;
+    protected $html;
+
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        $this->context = Context::getContext();
+        $this->shop_url = Tools::getHttpHost(true) . __PS_BASE_URI__;
+        $this->img_url = $this->shop_url . 'modules/' . $this->module_name . '/views/img/';
+        parent::__construct();
+        $this->assignCommonVars();
+    }
+
+    protected function assignCommonVars()
+    {
+        $moduleConfUrl = 'index.php?controller=AdminModules&configure=' . $this->module_name . '&token=' . Tools::getAdminTokenLite('AdminModules');
+        $postUrl = 'index.php?controller=AdminEverPsBlogPost&token=' . Tools::getAdminTokenLite('AdminEverPsBlogPost');
+        $authorUrl = 'index.php?controller=AdminEverPsBlogAuthor&token=' . Tools::getAdminTokenLite('AdminEverPsBlogAuthor');
+        $categoryUrl = 'index.php?controller=AdminEverPsBlogCategory&token=' . Tools::getAdminTokenLite('AdminEverPsBlogCategory');
+        $tagUrl = 'index.php?controller=AdminEverPsBlogTag&token=' . Tools::getAdminTokenLite('AdminEverPsBlogTag');
+        $commentUrl = 'index.php?controller=AdminEverPsBlogComment&token=' . Tools::getAdminTokenLite('AdminEverPsBlogComment');
+        $blogUrl = $this->context->link->getModuleLink($this->module_name, 'blog', [], true);
+        $ever_blog_token = Tools::encrypt('everpsblog/cron');
+        $emptytrash = $this->context->link->getModuleLink(
+            $this->module_name,
+            'emptytrash',
+            [
+                'token' => $ever_blog_token,
+                'id_shop' => (int) $this->context->shop->id,
+            ],
+            true,
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id
+        );
+        $pending = $this->context->link->getModuleLink(
+            $this->module_name,
+            'pending',
+            [
+                'token' => $ever_blog_token,
+                'id_shop' => (int) $this->context->shop->id,
+            ],
+            true,
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id
+        );
+        $planned = $this->context->link->getModuleLink(
+            $this->module_name,
+            'planned',
+            [
+                'token' => $ever_blog_token,
+                'id_shop' => (int) $this->context->shop->id,
+            ],
+            true,
+            (int) $this->context->language->id,
+            (int) $this->context->shop->id
+        );
+
+        $this->context->smarty->assign([
+            'image_dir' => $this->shop_url . 'modules/' . $this->module_name . '/views/img/',
+            'everpsblogcron' => $emptytrash,
+            'everpsblogcronpending' => $pending,
+            'everpsblogcronplanned' => $planned,
+            'moduleConfUrl' => $moduleConfUrl,
+            'authorUrl' => $authorUrl,
+            'postUrl' => $postUrl,
+            'categoryUrl' => $categoryUrl,
+            'tagUrl' => $tagUrl,
+            'commentUrl' => $commentUrl,
+            'blogUrl' => $blogUrl,
+        ]);
+    }
+
+    public function l($string, $class = null, $addslashes = false, $htmlentities = true)
+    {
+        return Context::getContext()->getTranslator()->trans(
+            $string,
+            [],
+            'Modules.Everpsblog.' . get_class($this)
+        );
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        $this->page_header_toolbar_btn['new'] = [
+            'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
+            'desc' => $this->l('Add new element'),
+            'icon' => 'process-icon-new',
+        ];
+        parent::initPageHeaderToolbar();
+    }
+
+    public function renderList()
+    {
+        $lists = parent::renderList();
+        $this->html = $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/' . $this->module_name . '/views/templates/admin/headerController.tpl'
+        );
+        $blog_instance = Module::getInstanceByName($this->module_name);
+        if ($blog_instance->checkLatestEverModuleVersion()) {
+            $this->html .= $this->context->smarty->fetch(
+                _PS_MODULE_DIR_ . '/' . $this->module_name . '/views/templates/admin/upgrade.tpl'
+            );
+        }
+        $this->html .= $lists;
+        $this->html .= $this->context->smarty->fetch(
+            _PS_MODULE_DIR_ . '/' . $this->module_name . '/views/templates/admin/footer.tpl'
+        );
+        return $this->html;
+    }
+
+    protected function processBulkDelete()
+    {
+        foreach (Tools::getValue($this->table . 'Box') as $idEverObj) {
+            $everObj = new $this->className((int) $idEverObj);
+            if (!$everObj->delete()) {
+                $this->errors[] = $this->l('An error has occurred: Can\'t delete the current object');
+            }
+        }
+    }
+
+    protected function displayError($message, $description = false)
+    {
+        array_push($this->errors, $this->module->l($message), $description);
+        return $this->setTemplate('error.tpl');
+    }
+}


### PR DESCRIPTION
## Summary
- create a shared `EverPsBlogAdminController`
- simplify controller constructors by extending new base class
- use base `renderList` and common vars
- show related posts count for authors, categories and tags

## Testing
- `php -l controllers/admin/EverPsBlogAdminController.php`
- `php -l controllers/admin/AdminEverPsBlogAuthorController.php`
- `php -l controllers/admin/AdminEverPsBlogCategoryController.php`
- `php -l controllers/admin/AdminEverpsBlogTagController.php`
- `php -l controllers/admin/AdminEverpsBlogPostController.php`
- `php -l controllers/admin/AdminEverpsBlogCommentController.php`


------
https://chatgpt.com/codex/tasks/task_e_68827f1657b08322b08745017352818f