### PR TITLE
Fix duplicate header/footer rendering in post admin list

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -236,26 +236,7 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
         if (Tools::isSubmit('submitBulkunprotectall' . $this->table)) {
             $this->processBulkUnprotect();
         }
-        $lists = parent::renderList();
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            . '/' . $this->module->name . '/views/templates/admin/headerController.tpl'
-        );
-        $blog_instance = Module::getInstanceByName($this->module->name);
-        if ($blog_instance->checkLatestEverModuleVersion()) {
-            $this->html .= $this->context->smarty->fetch(
-                _PS_MODULE_DIR_
-                . '/'
-                . $this->module->name
-                . '/views/templates/admin/upgrade.tpl'
-            );
-        }
-        $this->html .= $lists;
-        $this->html .= $this->context->smarty->fetch(
-            _PS_MODULE_DIR_
-            .'/' . $this->module->name . '/views/templates/admin/footer.tpl'
-        );
-        return $this->html;
+        return parent::renderList();
     }
 
     protected function getConfigFormValues($obj)


### PR DESCRIPTION
## Summary
- rely on parent renderList implementation for the post admin list
- prevent rendering the admin header and footer templates twice

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f049eb32c8322a42144e5fbae264e)