### PR TITLE
Include home post count in cache key

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -2468,13 +2468,11 @@ class EverPsBlog extends Module
     {
         $idLang = $this->context->language->id;
         $idShop = $this->context->shop->id;
-        $cacheId = $this->name . '-hookDisplayBanner-' . $idLang . '-' . $idShop;
+        $post_number = (int) Configuration::get('EVERPSBLOG_HOME_NBR') > 0
+            ? (int) Configuration::get('EVERPSBLOG_HOME_NBR')
+            : 4;
+        $cacheId = $this->name . '-hookDisplayBanner-' . $idLang . '-' . $idShop . '-' . $post_number;
         if (!$this->isCached('home.tpl', $cacheId)) {
-            if ((int) Configuration::get('EVERPSBLOG_HOME_NBR') > 0) {
-                $post_number = (int) Configuration::get('EVERPSBLOG_HOME_NBR');
-            } else {
-                $post_number = 4;
-            }
             $blogUrl = Context::getContext()->link->getModuleLink(
                 $this->name,
                 'blog',


### PR DESCRIPTION
## Summary
- include the configured home post count in the displayHome cache key so cache reflects configuration changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0a0a9ec08322a94ded26f7c304db)