### PR TITLE
Ensure admin controllers include navigation toolbar buttons

### DIFF
--- a/controllers/admin/AdminEverPsBlogAuthorController.php
+++ b/controllers/admin/AdminEverPsBlogAuthorController.php
@@ -132,6 +132,7 @@ class AdminEverPsBlogAuthorController extends EverPsBlogAdminController
 
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = [
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),

--- a/controllers/admin/AdminEverPsBlogCategoryController.php
+++ b/controllers/admin/AdminEverPsBlogCategoryController.php
@@ -142,6 +142,7 @@ class AdminEverPsBlogCategoryController extends EverPsBlogAdminController
 
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = [
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),

--- a/controllers/admin/AdminEverpsBlogCommentController.php
+++ b/controllers/admin/AdminEverpsBlogCommentController.php
@@ -96,6 +96,7 @@ class AdminEverPsBlogCommentController extends EverPsBlogAdminController
 
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = array(
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),

--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -164,6 +164,7 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
 
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = [
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),

--- a/controllers/admin/AdminEverpsBlogTagController.php
+++ b/controllers/admin/AdminEverpsBlogTagController.php
@@ -132,6 +132,7 @@ class AdminEverPsBlogTagController extends EverPsBlogAdminController
 
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = [
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),

--- a/controllers/admin/EverPsBlogAdminController.php
+++ b/controllers/admin/EverPsBlogAdminController.php
@@ -88,8 +88,43 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
         );
     }
 
+    protected function addToolbarNavigationButtons()
+    {
+        $this->page_header_toolbar_btn['module_config'] = [
+            'href' => 'index.php?controller=AdminModules&configure=' . $this->module_name . '&token=' . Tools::getAdminTokenLite('AdminModules'),
+            'desc' => $this->l('Module configuration'),
+            'icon' => 'process-icon-cogs',
+        ];
+        $this->page_header_toolbar_btn['posts'] = [
+            'href' => 'index.php?controller=AdminEverPsBlogPost&token=' . Tools::getAdminTokenLite('AdminEverPsBlogPost'),
+            'desc' => $this->l('Posts'),
+            'icon' => 'process-icon-list',
+        ];
+        $this->page_header_toolbar_btn['categories'] = [
+            'href' => 'index.php?controller=AdminEverPsBlogCategory&token=' . Tools::getAdminTokenLite('AdminEverPsBlogCategory'),
+            'desc' => $this->l('Categories'),
+            'icon' => 'process-icon-categories',
+        ];
+        $this->page_header_toolbar_btn['tags'] = [
+            'href' => 'index.php?controller=AdminEverPsBlogTag&token=' . Tools::getAdminTokenLite('AdminEverPsBlogTag'),
+            'desc' => $this->l('Tags'),
+            'icon' => 'process-icon-tag',
+        ];
+        $this->page_header_toolbar_btn['comments'] = [
+            'href' => 'index.php?controller=AdminEverPsBlogComment&token=' . Tools::getAdminTokenLite('AdminEverPsBlogComment'),
+            'desc' => $this->l('Comments'),
+            'icon' => 'process-icon-comments',
+        ];
+        $this->page_header_toolbar_btn['authors'] = [
+            'href' => 'index.php?controller=AdminEverPsBlogAuthor&token=' . Tools::getAdminTokenLite('AdminEverPsBlogAuthor'),
+            'desc' => $this->l('Authors'),
+            'icon' => 'process-icon-user',
+        ];
+    }
+
     public function initPageHeaderToolbar()
     {
+        $this->addToolbarNavigationButtons();
         $this->page_header_toolbar_btn['new'] = [
             'href' => self::$currentIndex . '&add' . $this->table . '&token=' . $this->token,
             'desc' => $this->l('Add new element'),


### PR DESCRIPTION
## Summary
- add a reusable helper to build blog navigation toolbar buttons
- call the helper from each admin controller toolbar to include navigation across all back-office pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f119d91908322898143a3a6c8b248)