### PR TITLE
Fix post grid filters for shop and language

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -149,7 +149,7 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
                     AND acl.`id_lang` = ' . (int) Context::getContext()->language->id . '
                 )';
         $this->_where = 'AND a.id_shop = ' . (int) Context::getContext()->shop->id;
-        $this->_where = 'AND l.id_lang = ' . (int) Context::getContext()->language->id;
+        $this->_where .= ' AND l.id_lang = ' . (int) Context::getContext()->language->id;
         parent::__construct();
     }
 


### PR DESCRIPTION
## Summary
- keep both shop and language filters when building admin post grid query

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1530d940832281ea1a5b4f2a816c)