### PR TITLE
Show social sharing buttons when links exist

### DIFF
--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -144,7 +144,7 @@
         </div>
             <div class="col-12 col-md-6">
           {if $social_share_links}
-            <div class="social-sharing d-none">
+            <div class="social-sharing">
               <span>{l s='Share' d='Shop.Theme.Actions'}</span>
               <ul>
                 {foreach from=$social_share_links item='social_share_link'}


### PR DESCRIPTION
## Summary
- remove the utility class hiding the social sharing block so links display when provided

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f1641ad208322a27d103d1bc26e3a)