### PR TITLE
Add accessible label to blog search input

### DIFF
--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -79,7 +79,8 @@
 <div class="d-flex justify-content-center mb-3">
     <form method="get" action="{$link->getModuleLink('everpsblog','search')|escape:'htmlall':'UTF-8'}" class="everpsblog-search" data-doofinder-ignore="true">
         <div class="input-group">
-            <input class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search by keywords' mod='everpsblog'}" required />
+            <label class="input-group-text" for="everpsblog-search-input">{l s='Search the blog' mod='everpsblog'}</label>
+            <input id="everpsblog-search-input" class="form-control" type="search" name="s" data-doofinder-ignore="true" placeholder="{l s='Search by keywords' mod='everpsblog'}" required />
             <button class="btn btn-info" type="submit">{l s='Search' mod='everpsblog'}</button>
         </div>
     </form>


### PR DESCRIPTION
## Summary
- add labeled search input for blog search form
- assign matching id and label to improve accessibility while keeping existing styling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f161f328c83229d56bf02a591ad5d)