### PR TITLE
Update home slider to show four posts per slide

### DIFF
--- a/views/templates/hook/home.tpl
+++ b/views/templates/hook/home.tpl
@@ -26,34 +26,40 @@
         </div>
         {if $everpsblog|@count > 1}
             {assign var=carousel_id value='everpsblog-home-slider-'|cat:uniqid()}
-            <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="carousel" data-bs-interval="false" data-bs-wrap="true">
+            <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
                 <div class="carousel-inner">
                     {foreach from=$everpsblog item=item name=homecarousel}
-                        <div class="carousel-item {if $smarty.foreach.homecarousel.first}active{/if}">
-                            <div class="article everpsblog" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
-                                <div class="col-12 article-img {$blogcolor|escape:'htmlall':'UTF-8'}">
-                                    {if isset($show_featured_post) && $show_featured_post}
-                                        <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img-fluid col-12 w-100 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" />
-                                    {/if}
-                                </div>
-                                <div class="col-12">
-                                    <h3 class="everpsblog article-content" id="everpsblog-post-title-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
-                                        <a href="{$link->getModuleLink('everpsblog', 'post', ['id_ever_post' => $item->id_ever_post , 'link_rewrite' => $item->link_rewrite])|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" class="{$blogcolor|escape:'htmlall':'UTF-8'}">
-                                            {$item->title|escape:'htmlall':'UTF-8'}
-                                        </a>
-                                    </h3>
-                                    {if isset($item->default_cat_obj) && $item->default_cat_obj}
-                                        <a href="{$link->getModuleLink('everpsblog', 'category', ['id_ever_category'=>$item->default_cat_obj->id_ever_category, 'link_rewrite'=>$item->default_cat_obj->link_rewrite])|escape:'htmlall':'UTF-8'}" class="d-block {$blogcolor|escape:'htmlall':'UTF-8'}" title="{$item->default_cat_obj->title|escape:'htmlall':'UTF-8'}">
-                                            {$item->default_cat_obj->title|escape:'htmlall':'UTF-8'}
-                                        </a>
-                                    {/if}
-                                    <div class="everpsblogcontent rte" id="everpsblog-post-content-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
-                                        {if isset($item->excerpt) && !empty($item->excerpt)}{$item->excerpt|escape:'htmlall':'UTF-8'}{else}{$item->content|escape:'htmlall':'UTF-8'}{/if}
+                        {if $smarty.foreach.homecarousel.index % 4 == 0}
+                            <div class="carousel-item {if $smarty.foreach.homecarousel.first}active{/if}">
+                                <div class="row">
+                        {/if}
+                                    <div class="col-12 col-sm-6 col-lg-3 mb-3 article everpsblog" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+                                        <div class="col-12 article-img {$blogcolor|escape:'htmlall':'UTF-8'}">
+                                            {if isset($show_featured_post) && $show_featured_post}
+                                                <img src="{$item->featured_thumb|escape:'htmlall':'UTF-8'}" width="320" height="180" class="img-fluid col-12 w-100 {if $animated}animated flipSideBySide zoomed{/if}" alt="{$item->title|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" />
+                                            {/if}
+                                        </div>
+                                        <div class="col-12">
+                                            <h3 class="everpsblog article-content" id="everpsblog-post-title-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+                                                <a href="{$link->getModuleLink('everpsblog', 'post', ['id_ever_post' => $item->id_ever_post , 'link_rewrite' => $item->link_rewrite])|escape:'htmlall':'UTF-8'}" title="{$item->title|escape:'htmlall':'UTF-8'}" class="{$blogcolor|escape:'htmlall':'UTF-8'}">
+                                                    {$item->title|escape:'htmlall':'UTF-8'}
+                                                </a>
+                                            </h3>
+                                            {if isset($item->default_cat_obj) && $item->default_cat_obj}
+                                                <a href="{$link->getModuleLink('everpsblog', 'category', ['id_ever_category'=>$item->default_cat_obj->id_ever_category, 'link_rewrite'=>$item->default_cat_obj->link_rewrite])|escape:'htmlall':'UTF-8'}" class="d-block {$blogcolor|escape:'htmlall':'UTF-8'}" title="{$item->default_cat_obj->title|escape:'htmlall':'UTF-8'}">
+                                                    {$item->default_cat_obj->title|escape:'htmlall':'UTF-8'}
+                                                </a>
+                                            {/if}
+                                            <div class="everpsblogcontent rte" id="everpsblog-post-content-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
+                                                {if isset($item->excerpt) && !empty($item->excerpt)}{$item->excerpt|escape:'htmlall':'UTF-8'}{else}{$item->content|escape:'htmlall':'UTF-8'}{/if}
+                                            </div>
+                                            <a href="{$link->getModuleLink('everpsblog', 'post', ['id_ever_post' => $item->id_ever_post , 'link_rewrite' => $item->link_rewrite])|escape:'htmlall':'UTF-8'}" class="{$blogcolor|escape:'htmlall':'UTF-8'}" title="{l s='Read more' mod='everpsblog'} {$item->title|escape:'htmlall':'UTF-8'}">&gt;&gt; {l s='Read more' mod='everpsblog'}</a>
+                                        </div>
                                     </div>
-                                    <a href="{$link->getModuleLink('everpsblog', 'post', ['id_ever_post' => $item->id_ever_post , 'link_rewrite' => $item->link_rewrite])|escape:'htmlall':'UTF-8'}" class="{$blogcolor|escape:'htmlall':'UTF-8'}" title="{l s='Read more' mod='everpsblog'} {$item->title|escape:'htmlall':'UTF-8'}">&gt;&gt; {l s='Read more' mod='everpsblog'}</a>
+                        {if $smarty.foreach.homecarousel.index % 4 == 3 || $smarty.foreach.homecarousel.last}
                                 </div>
                             </div>
-                        </div>
+                        {/if}
                     {/foreach}
                 </div>
                 <a class="carousel-control-prev" role="button" data-bs-target="#{$carousel_id|escape:'htmlall':'UTF-8'}" data-bs-slide="prev">


### PR DESCRIPTION
## Summary
- group home page blog posts four per carousel slide to match requested layout
- disable automatic rotation on the home blog slider

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f18d9e8ec83229cb21f0e198cb5dc)