### PR TITLE
Improve comment layout and form guidance

### DIFF
--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -194,32 +194,49 @@
         <div class="col-12">
             <div class="card shadow-sm border-0 mb-3">
                 <div class="card-body">
-                    <span id="leaveComment" class="h5 d-block mb-3">{l s='Leave a comment' mod='everpsblog'}</span>
-                    <form enctype="multipart/form-data" method="post">
+                    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-3">
+                        <span id="leaveComment" class="h5 mb-2 mb-md-0">{l s='Leave a comment' mod='everpsblog'}</span>
+                        <span class="text-muted small">{l s='Fields marked with * are required.' mod='everpsblog'}</span>
+                    </div>
+                    <form enctype="multipart/form-data" method="post" class="comment-form">
             {if isset($logged) && $logged}
             <input type="hidden" name="customerEmail" id="customerEmail" value="{$customer.email|escape:'htmlall':'UTF-8'}">
             {else}
             <div class="mb-3">
-                <label for="customerEmail">{l s='Email address' mod='everpsblog'}</label>
-                <input type="email" class="form-control" id="customerEmail" name="customerEmail" aria-describedby="emailHelp" placeholder="Enter email">
+                <label for="customerEmail" class="form-label">{l s='Email address *' mod='everpsblog'}</label>
+                <input type="email" class="form-control" id="customerEmail" name="customerEmail" aria-describedby="emailHelp" placeholder="{l s='Enter your email' mod='everpsblog'}" required>
                 <small id="emailHelp" class="form-text text-muted">{l s='We\'ll never share your email with anyone else.' mod='everpsblog'}</small>
+                <div class="invalid-feedback d-block" style="display:none;" data-error-for="customerEmail" data-message="{l s='Please enter a valid email address.' mod='everpsblog'}"></div>
             </div>
             <div class="mb-3">
-                <label for="name">{l s='Name' mod='everpsblog'}</label>
-                <input type="text" class="form-control" id="name" name="name" aria-describedby="nameHelp" placeholder="Enter your name">
+                <label for="name" class="form-label">{l s='Name *' mod='everpsblog'}</label>
+                <input type="text" class="form-control" id="name" name="name" aria-describedby="nameHelp" placeholder="{l s='Enter your name' mod='everpsblog'}" required>
+                <small id="nameHelp" class="form-text text-muted">{l s='This will be displayed with your comment.' mod='everpsblog'}</small>
+                <div class="invalid-feedback d-block" style="display:none;" data-error-for="name" data-message="{l s='Please enter your name.' mod='everpsblog'}"></div>
             </div>
             {/if}
             <div class="mb-3">
-            <label for="evercomment">{l s='Your comment' mod='everpsblog'}</label>
-            <textarea class="form-control" id="evercomment" name="evercomment" rows="3"></textarea>
+                <div class="d-flex justify-content-between align-items-center">
+                    <label for="evercomment" class="form-label mb-0">{l s='Your comment *' mod='everpsblog'}</label>
+                    <small class="text-muted" id="commentCounter" data-maxlength="800">0/800</small>
+                </div>
+                <textarea class="form-control" id="evercomment" name="evercomment" rows="3" maxlength="800" aria-describedby="commentHelp" required></textarea>
+                <small id="commentHelp" class="form-text text-muted">{l s='Share your thoughts in a constructive way. Maximum 800 characters.' mod='everpsblog'}</small>
+                <div class="invalid-feedback d-block" style="display:none;" data-error-for="evercomment" data-message="{l s='Please add a comment.' mod='everpsblog'}"></div>
             </div>
-            <div class="form-check">
-            <input class="form-check-input" type="checkbox" value="1" id="RgpdCompliance" name="RgpdCompliance">
-            <label class="form-check-label" for="RgpdCompliance">
-                {l s='RGPD compliance' mod='everpsblog'}
-            </label>
+            <div class="form-check form-switch mb-4 p-0">
+                <div class="d-flex align-items-center">
+                    <input class="form-check-input me-2" type="checkbox" value="1" id="RgpdCompliance" name="RgpdCompliance">
+                    <label class="form-check-label fw-semibold" for="RgpdCompliance">
+                        {l s='RGPD compliance' mod='everpsblog'}
+                    </label>
+                </div>
+                <small class="text-muted d-block mt-1">{l s='By enabling this option, you agree that your comment may be stored according to our privacy policy.' mod='everpsblog'}</small>
             </div>
-            <button type="submit" class="btn btn-primary btn-blog-primary" id="everpostcomment" name="everpostcomment">{l s='Submit' mod='everpsblog'}</button>
+            <div class="d-flex flex-wrap gap-2">
+                <button type="submit" class="btn btn-primary btn-blog-primary" id="everpostcomment" name="everpostcomment">{l s='Submit' mod='everpsblog'}</button>
+                <button type="reset" class="btn btn-secondary">{l s='Reset' mod='everpsblog'}</button>
+            </div>
                     </form>
                 </div>
             </div>
@@ -228,31 +245,92 @@
 </section>
 {/if}
 
+<script>
+{literal}
+document.addEventListener('DOMContentLoaded', function () {
+    const commentField = document.getElementById('evercomment');
+    const counter = document.getElementById('commentCounter');
+    const form = document.querySelector('.comment-form');
+    const fields = ['customerEmail', 'name', 'evercomment'];
+
+    const updateCounter = () => {
+        if (!commentField || !counter) {
+            return;
+        }
+        const max = parseInt(counter.dataset.maxlength, 10) || commentField.maxLength || 0;
+        const current = commentField.value.length;
+        counter.textContent = max ? `${current}/${max}` : `${current}`;
+    };
+
+    updateCounter();
+
+    if (commentField) {
+        commentField.addEventListener('input', updateCounter);
+    }
+
+    if (form) {
+        form.addEventListener('submit', function (event) {
+            let hasError = false;
+            fields.forEach(function (fieldName) {
+                const field = document.getElementById(fieldName);
+                const errorContainer = document.querySelector(`[data-error-for="${fieldName}"]`);
+                if (errorContainer) {
+                    errorContainer.style.display = 'none';
+                    errorContainer.textContent = '';
+                }
+                if (field && field.hasAttribute('required') && !field.value.trim()) {
+                    hasError = true;
+                    if (errorContainer) {
+                        errorContainer.style.display = 'block';
+                        errorContainer.textContent = errorContainer.dataset.message || 'This field is required.';
+                    }
+                }
+            });
+
+            if (hasError) {
+                event.preventDefault();
+            }
+        });
+    }
+});
+{/literal}
+</script>
+
 {if isset($commentsCount) && $commentsCount > 0}
 {hook h="displayBeforeEverComment"}
-<section class="comments container clearfix mt-2">
-    <span id="commentsTitle">{$commentsCount|escape:'htmlall':'UTF-8'} {l s='comment(s)' mod='everpsblog'}</span>
-    <div class="commentcontainer row mt-3">
-        {foreach from=$comments item=comment}
-            <div class="col-12 col-md-6 mb-3" id="{$comment->id|escape:'htmlall':'UTF-8'}">
-                <div class="card h-100 shadow-sm border-0 commentblock">
-                    <div class="card-body">
-                        <div class="row">
-                            <div class="col-12 col-md-8 commentname">
-                                <strong>{$comment->name|escape:'htmlall':'UTF-8'}</strong>
-                            </div>
-                            <div class="col-12 col-md-4 commentdate text-md-right text-muted">
-                                {$comment->date_upd|escape:'htmlall':'UTF-8'}
-                            </div>
-                            <div class="col-12 comment mt-2">
-                                <div class="rte">
-                                    {$comment->comment nofilter}
-                                </div>
-                            </div>
+<section class="comments container clearfix mt-4">
+    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3">
+        <div class="d-flex align-items-center">
+            <h2 id="commentsTitle" class="h5 mb-0">{l s='Comments' mod='everpsblog'}</h2>
+            <span class="badge bg-secondary text-white ms-2">{$commentsCount|escape:'htmlall':'UTF-8'}</span>
+        </div>
+        <small class="text-muted">{l s='Join the discussion below.' mod='everpsblog'}</small>
+    </div>
+    <div class="commentcontainer mt-3">
+        {foreach from=$comments item=comment name=commentLoop}
+            {assign var=commentInitial value=$comment->name|substr:0:1|escape:'htmlall':'UTF-8'}
+            <article class="d-flex py-3 {if !$smarty.foreach.commentLoop.last}border-bottom{/if}" id="{$comment->id|escape:'htmlall':'UTF-8'}">
+                <div class="flex-shrink-0 me-3">
+                    {if isset($comment->image) && $comment->image}
+                        <img src="{$comment->image|escape:'htmlall':'UTF-8'}" alt="{$comment->name|escape:'htmlall':'UTF-8'}" class="rounded-circle" style="width:48px;height:48px;object-fit:cover;">
+                    {else}
+                        <div class="rounded-circle bg-secondary text-white d-flex align-items-center justify-content-center" style="width:48px;height:48px;">
+                            <span class="fw-semibold">{$commentInitial|escape:'htmlall':'UTF-8'}</span>
+                        </div>
+                    {/if}
+                </div>
+                <div class="flex-grow-1">
+                    <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between">
+                        <strong class="commentname">{$comment->name|escape:'htmlall':'UTF-8'}</strong>
+                        <span class="commentdate text-muted small">{$comment->date_upd|escape:'htmlall':'UTF-8'}</span>
+                    </div>
+                    <div class="comment mt-2">
+                        <div class="rte mb-0">
+                            {$comment->comment nofilter}
                         </div>
                     </div>
                 </div>
-            </div>
+            </article>
         {/foreach}
     </div>
 </section>


### PR DESCRIPTION
## Summary
- restructure comment list with header badge, avatars, and clearer separation between entries
- enhance comment form with inline help text, validation messaging placeholders, and RGPD emphasis
- add character counter and secondary reset button while improving spacing for readability

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f18f2558c832296c2da4355b29af6)