### PR TITLE
Improve bulk delete validation and permissions

### DIFF
--- a/controllers/admin/EverPsBlogAdminController.php
+++ b/controllers/admin/EverPsBlogAdminController.php
@@ -154,10 +154,30 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
 
     protected function processBulkDelete()
     {
-        foreach (Tools::getValue($this->table . 'Box') as $idEverObj) {
-            $everObj = new $this->className((int) $idEverObj);
+        if (!$this->access('delete')) {
+            $this->errors[] = $this->l('You do not have permission to delete this item.');
+
+            return;
+        }
+
+        $idsToDelete = Tools::getValue($this->table . 'Box');
+        if (!is_array($idsToDelete) || empty($idsToDelete)) {
+            return;
+        }
+
+        foreach ($idsToDelete as $idEverObj) {
+            $idEverObj = (int) $idEverObj;
+
+            if ($idEverObj <= 0) {
+                continue;
+            }
+
+            $everObj = new $this->className($idEverObj);
             if (!$everObj->delete()) {
-                $this->errors[] = $this->l('An error has occurred: Can\'t delete the current object');
+                $this->errors[] = sprintf(
+                    $this->l('An error has occurred: Can\'t delete the current object with ID %d'),
+                    $idEverObj
+                );
             }
         }
     }


### PR DESCRIPTION
## Summary
- add delete access guard with user-facing error before bulk deletion
- validate bulk delete input list and sanitize identifiers before processing
- report the failed object id when deletions do not succeed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f195ef7dc832296c7c8084165f4ed)