### PR TITLE
Improve blog filter UI and interactions

### DIFF
--- a/views/js/everpsblog.js
+++ b/views/js/everpsblog.js
@@ -54,27 +54,119 @@ $(document).ready(function(){
     }
 
     if ($('#everpsblog-filter').length) {
-        $('#everpsblog-filter-submit').on('click', function() {
-            var cat = $('#everpsblog-category').val();
-            var tag = $('#everpsblog-tag').val();
-            if ((!cat || cat === '0') && (!tag || tag === '0')) {
+        var $filterForm = $('#everpsblog-filter');
+        var $filterButton = $('#everpsblog-filter-submit');
+        var $filterLoading = $('#everpsblog-filter-loading');
+        var $resetButton = $('#everpsblog-filter-reset');
+        var $postsContainer = $('#everpsblog-posts');
+        var $activeFilters = $('#everpsblog-active-filters');
+        var $activeSummary = $('#everpsblog-active-filters-summary');
+        var defaultSummaryText = $activeSummary.data('defaultText');
+        var activePrefix = $activeFilters.data('activePrefix');
+        var categoryLabel = $activeFilters.data('categoryLabel');
+        var tagLabel = $activeFilters.data('tagLabel');
+        var emptyText = $postsContainer.data('emptyText') || '';
+        var defaultPostsHtml = $postsContainer.length ? $postsContainer.html() : '';
+
+        var updateActiveFilters = function(catValue, tagValue) {
+            var activeLabels = [];
+            if (catValue && catValue !== '0') {
+                activeLabels.push(categoryLabel + ' ' + $('#everpsblog-category option:selected').text());
+            }
+            if (tagValue && tagValue !== '0') {
+                activeLabels.push(tagLabel + ' ' + $('#everpsblog-tag option:selected').text());
+            }
+
+            if (activeLabels.length) {
+                $activeSummary.text(activePrefix + ' ' + activeLabels.join(' • '));
+                $resetButton.prop('disabled', false);
+            } else {
+                $activeSummary.text(defaultSummaryText);
+                $resetButton.prop('disabled', true);
+            }
+        };
+
+        var toggleLoading = function(isLoading, catValue, tagValue) {
+            $filterButton.prop('disabled', isLoading);
+            $resetButton.prop('disabled', isLoading ? true : $resetButton.prop('disabled'));
+
+            if (isLoading) {
+                $filterLoading.removeClass('d-none');
                 return;
             }
+
+            $filterLoading.addClass('d-none');
+            updateActiveFilters(catValue, tagValue);
+        };
+
+        var renderEmptyState = function() {
+            if (!$postsContainer.length) {
+                return;
+            }
+            $postsContainer.html('<div class="alert alert-warning text-center mb-0">' + emptyText + '</div>');
+        };
+
+        var fetchFilteredPosts = function(catValue, tagValue) {
+            var requestUrl = $filterForm.data('filterUrl') || (typeof facetUrl !== 'undefined' ? facetUrl : '');
+
+            if (!requestUrl) {
+                renderEmptyState();
+                updateActiveFilters(catValue, tagValue);
+                return;
+            }
+
+            toggleLoading(true, catValue, tagValue);
+
             $.ajax({
-                url: typeof facetUrl !== 'undefined' ? facetUrl : '',
+                url: requestUrl,
                 method: 'GET',
                 data: {
-                    category: cat,
-                    tag: tag,
+                    category: catValue,
+                    tag: tagValue,
                     ajax: 1
                 },
                 dataType: 'json'
             }).done(function(resp){
-                if (resp.html !== undefined) {
-                    $('#everpsblog-posts').html(resp.html);
-                    $(document).trigger('everpsblogAjaxLoaded');
+                if (resp && resp.html !== undefined && String(resp.html).trim() !== '') {
+                    $postsContainer.html(resp.html);
+                } else {
+                    renderEmptyState();
                 }
+            }).fail(function() {
+                renderEmptyState();
+            }).always(function() {
+                toggleLoading(false, catValue, tagValue);
+                $(document).trigger('everpsblogAjaxLoaded');
             });
+        };
+
+        $filterForm.on('submit', function(event) {
+            event.preventDefault();
+            var catValue = $('#everpsblog-category').val();
+            var tagValue = $('#everpsblog-tag').val();
+
+            if ((!catValue || catValue === '0') && (!tagValue || tagValue === '0')) {
+                $postsContainer.html(defaultPostsHtml);
+                updateActiveFilters(catValue, tagValue);
+                return;
+            }
+
+            fetchFilteredPosts(catValue, tagValue);
         });
+
+        $filterButton.on('click', function() {
+            $filterForm.trigger('submit');
+        });
+
+        $resetButton.on('click', function() {
+            if ($resetButton.prop('disabled')) {
+                return;
+            }
+            $filterForm[0].reset();
+            $postsContainer.html(defaultPostsHtml);
+            updateActiveFilters('0', '0');
+        });
+
+        updateActiveFilters($('#everpsblog-category').val(), $('#everpsblog-tag').val());
     }
 });

--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -97,9 +97,15 @@
         <div class="col-12 col-lg-10">
             <div class="card shadow-sm border-0">
                 <div class="card-body">
-                    <form id="everpsblog-filter" class="row" onsubmit="return false;">
+                    <div id="everpsblog-active-filters" class="alert alert-secondary d-flex flex-column flex-md-row align-items-md-center justify-content-between mb-3" data-active-prefix="{l s='Active filters:' mod='everpsblog'}" data-category-label="{l s='Category:' mod='everpsblog'}" data-tag-label="{l s='Tag:' mod='everpsblog'}">
+                        <span id="everpsblog-active-filters-summary" data-default-text="{l s='No filter applied' mod='everpsblog'}">{l s='No filter applied' mod='everpsblog'}</span>
+                        <div class="d-flex align-items-center gap-2 mt-2 mt-md-0">
+                            <button type="button" id="everpsblog-filter-reset" class="btn btn-outline-secondary btn-sm" disabled>{l s='Reset' mod='everpsblog'}</button>
+                        </div>
+                    </div>
+                    <form id="everpsblog-filter" class="row g-3 g-md-4 align-items-end" data-filter-url="{if isset($facet_url)}{$facet_url|escape:'htmlall':'UTF-8'}{/if}">
                         {if isset($evercategory) && $evercategory|count > 0}
-                        <div class="col-12 col-md-4 mb-3 mb-md-0">
+                        <div class="col-12 col-md-4">
                             <label class="d-block mb-1" for="everpsblog-category">{l s='Category' mod='everpsblog'}</label>
                             <select id="everpsblog-category" class="form-select custom-select" name="category">
                                 <option value="0">{l s='Category' mod='everpsblog'}</option>
@@ -112,7 +118,7 @@
                         </div>
                         {/if}
                         {if isset($evertags) && $evertags|count > 0}
-                        <div class="col-12 col-md-4 mb-3 mb-md-0">
+                        <div class="col-12 col-md-4">
                             <label class="d-block mb-1" for="everpsblog-tag">{l s='Tag' mod='everpsblog'}</label>
                             <select id="everpsblog-tag" class="form-select custom-select" name="tag">
                                 <option value="0">{l s='Tag' mod='everpsblog'}</option>
@@ -122,8 +128,13 @@
                             </select>
                         </div>
                         {/if}
-                        <div class="col-12 col-md-4 d-flex align-items-end justify-content-start justify-content-md-end">
-                            <button id="everpsblog-filter-submit" class="btn btn-primary w-100">{l s='Filter' mod='everpsblog'}</button>
+                        <div class="col-12 col-md-4">
+                            <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-end gap-2">
+                                <button id="everpsblog-filter-submit" type="submit" class="btn btn-primary w-100">
+                                    <span class="everpsblog-filter-submit-label">{l s='Filter' mod='everpsblog'}</span>
+                                    <span class="spinner-border spinner-border-sm ms-2 d-none" id="everpsblog-filter-loading" role="status" aria-hidden="true"></span>
+                                </button>
+                            </div>
                         </div>
                     </form>
                 </div>
@@ -160,7 +171,7 @@
 {/if}
 
 {if isset($post_number) && $post_number > 0}
-<div class="row mt-2" id="everpsblog-posts">
+<div class="row mt-2" id="everpsblog-posts" data-empty-text="{l s='No posts match your filters yet.' mod='everpsblog'}">
 {hook h="displayBeforeEverLoop"}
 {foreach from=$everpsblog item=item}
 {include file='module:everpsblog/views/templates/front/loop/post_array.tpl'}


### PR DESCRIPTION
## Summary
- add an active-filter banner with reset control and consistent filter layout on mobile and desktop
- show loading feedback during filtering and display a clear empty state when no results are returned
- rewrite filter JavaScript to submit explicitly, manage reset state, and restore the default list when filters are cleared

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f18f3cb548322a0f65654954c71bb)