### PR TITLE
Fix missing column use in blog post list

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -133,7 +133,6 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
                 ON (
                     l.`' . $this->identifier . '` = a.`' . $this->identifier . '`
                     AND l.`id_lang` = ' . (int) Context::getContext()->language->id . '
-                    AND l.`id_shop` = ' . (int) Context::getContext()->shop->id . '
                 )
             LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_author` au
                 ON (


### PR DESCRIPTION
## Summary
- remove invalid shop filter from post translations join to prevent missing column errors

## Testing
- php -l controllers/admin/AdminEverpsBlogPostController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff9b836d48322b2a3949a6a924628)