### PR TITLE
Fix post slider carousel id

### DIFF
--- a/views/templates/block/post-slider.tpl
+++ b/views/templates/block/post-slider.tpl
@@ -18,7 +18,8 @@
 {if isset($block.extra.states) && $block.extra.states|@count}
 <div class="everpsblog-block everpsblog-post-slider">
     {if isset($block.settings.bootstrap_slider) && $block.settings.bootstrap_slider}
-        <div id="block-{$block.id_prettyblocks}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
+        {assign var=carousel_id value='everpsblog-post-slider-'|cat:$block.id_prettyblocks}
+        <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
             <div class="carousel-inner">
                 {foreach from=$block.extra.states item=post name=postslider}
                 {assign var="post" value=$post.post}


### PR DESCRIPTION
## Summary
- assign a dedicated carousel identifier for the post slider template
- ensure navigation controls target the correct carousel so infinite sliding works

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69300b40070c832291876cedfc6c9792)