### PR TITLE
Enable infinite looping for Prettyblocks sliders

### DIFF
--- a/views/templates/block/category-slider.tpl
+++ b/views/templates/block/category-slider.tpl
@@ -7,7 +7,7 @@
 
     {if isset($block.settings.bootstrap_slider) && $block.settings.bootstrap_slider && isset($carousel_id)}
         {assign var=carousel_id value='everpsblog-post-slider-'|cat:$block.id_prettyblocks}
-        <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
+        <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true" data-wrap="true">
 
             <div class="carousel-inner">
 

--- a/views/templates/block/post-slider.tpl
+++ b/views/templates/block/post-slider.tpl
@@ -19,7 +19,7 @@
 <div class="everpsblog-block everpsblog-post-slider">
     {if isset($block.settings.bootstrap_slider) && $block.settings.bootstrap_slider}
         {assign var=carousel_id value='everpsblog-post-slider-'|cat:$block.id_prettyblocks}
-        <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
+        <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true" data-wrap="true">
             <div class="carousel-inner">
                 {foreach from=$block.extra.states item=post name=postslider}
                 {assign var="post" value=$post.post}


### PR DESCRIPTION
### Motivation
- Prettyblocks sliders should loop infinitely so users can cycle through items without stopping.
- Adding an explicit `data-wrap="true"` ensures the Bootstrap carousel actually wraps in environments where `data-bs-wrap` may not be honored.

### Description
- Added `data-wrap="true"` to the carousel container in `views/templates/block/post-slider.tpl`.
- Added `data-wrap="true"` to the carousel container in `views/templates/block/category-slider.tpl`.
- This change complements the existing `data-bs-wrap="true"` attribute to improve compatibility and enforce infinite looping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69651757f45083229087d8f1d5c50107)