### PR TITLE
Add `Container` class to `bloghome` wrapper in home template

### DIFF
--- a/views/templates/hook/home.tpl
+++ b/views/templates/hook/home.tpl
@@ -16,7 +16,7 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 {if isset($everpsblog) && $everpsblog|@count}
-    <div class="bloghome">
+    <div class="bloghome Container">
         <div class="row bloghometitle">
             <a href="{$blogUrl|escape:'htmlall':'UTF-8'}" title="{l s='Latest posts from the blog' mod='everpsblog'}">
                 <h2 class="h2 products-section-title text-uppercase text-center">
@@ -72,7 +72,7 @@
                 </a>
             </div>
         {else}
-            <div class="bloghome mt-2 row">
+            <div class="bloghome Container mt-2 row">
                 {foreach from=$everpsblog item=item}
                     <div class="col-12 col-sm-6 col-lg-3 mb-3 article everpsblog" id="everpsblog-{$item->id_ever_post|escape:'htmlall':'UTF-8'}">
                         <div class="col-12 article-img {$blogcolor|escape:'htmlall':'UTF-8'}">


### PR DESCRIPTION
### Motivation

- Ensure the `bloghome` wrapper works inside Prettyblock layouts that expect a `Container` class for proper layout alignment. 
- Keep consistent container styling for the blog block on the homepage when rendered inside themes or builders that rely on a `Container` element. 

### Description

- Updated `views/templates/hook/home.tpl` to add the `Container` class to the outer `div` with class `bloghome`. 
- Also added `Container` to the secondary `div` variant `bloghome mt-2 row` so both rendering branches are covered. 
- The file change was saved and committed. 

### Testing

- No automated tests were run for this change. 
- Changes are limited to template markup and do not include runtime logic modifications.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966035080b08322b1d677c18215ed40)