### PR TITLE
Fix home carousel id assignment

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -2508,6 +2508,7 @@ class EverPsBlog extends Module
                 'EVERBLOG_ANIMATE'
             );
             $siteUrl = Tools::getHttpHost(true) . __PS_BASE_URI__;
+            $carouselId = 'everpsblog-home-slider-' . uniqid('', true);
             $this->context->smarty->assign([
                 'blogcolor' => Configuration::get('EVERBLOG_CSS_FILE'),
                 'blogUrl' => $blogUrl,
@@ -2518,6 +2519,7 @@ class EverPsBlog extends Module
                 'blogImg_dir' => $siteUrl . '/modules/everpsblog/views/img/',
                 'animated' => $animate,
                 'show_featured_post' => true,
+                'carousel_id' => $carouselId,
             ]);
         }
         return $this->display(__FILE__, 'views/templates/hook/home.tpl', $cacheId);

--- a/views/templates/hook/home.tpl
+++ b/views/templates/hook/home.tpl
@@ -25,7 +25,6 @@
             </a>
         </div>
         {if $everpsblog|@count > 1}
-            {assign var=carousel_id value='everpsblog-home-slider-'|cat:uniqid()}
             <div id="{$carousel_id|escape:'htmlall':'UTF-8'}" class="carousel slide" data-bs-ride="false" data-bs-interval="false" data-bs-wrap="true">
                 <div class="carousel-inner">
                     {foreach from=$everpsblog item=item name=homecarousel}


### PR DESCRIPTION
### Motivation
- Prevent generating the carousel DOM id inside the Smarty template to avoid template-side `uniqid` usage and potential caching/duplicate id issues.
- Ensure a single unique id is produced on the PHP side so templates can rely on a precomputed value.
- Make the hook output deterministic for cached templates by computing the id before assigning Smarty variables.

### Description
- Generate the carousel id in `hookDisplayHome` with `$carouselId = 'everpsblog-home-slider-' . uniqid('', true);` and assign it to Smarty as `carousel_id` in `everpsblog.php`.
- Remove the Smarty-side `{assign var=carousel_id value='everpsblog-home-slider-'|cat:uniqid()}` from `views/templates/hook/home.tpl` and use the assigned `{$carousel_id}` directly.
- Updated files: `everpsblog.php` and `views/templates/hook/home.tpl` to centralize id generation in PHP.

### Testing
- No automated tests were executed for this change.
- Changes were committed and both modified files were staged and recorded in a commit titled `Fix home carousel id assignment`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966080088bc832298275da3ff304164)