### PR TITLE
Fix category shop join in admin post list

### DIFF
--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -147,7 +147,11 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
                 ON (
                     acl.`id_ever_category` = a.`id_default_category`
                     AND acl.`id_lang` = ' . (int) Context::getContext()->language->id . '
-                    AND acl.`id_shop` = ' . (int) Context::getContext()->shop->id . '
+                )
+            LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_category_shop` acs
+                ON (
+                    acs.`id_ever_category` = a.`id_default_category`
+                    AND acs.`id_shop` = ' . (int) Context::getContext()->shop->id . '
                 )';
         $this->_where = 'AND a.id_shop = ' . (int) Context::getContext()->shop->id;
         $this->_where .= ' AND l.id_lang = ' . (int) Context::getContext()->language->id;


### PR DESCRIPTION
### Motivation
- The admin posts list triggered an SQL error due to referencing a non-existent `id_shop` column on the `ever_blog_category_lang` table when joining category data. 
- The intent is to correctly scope category language rows to the current shop by using the category-to-shop mapping table instead of filtering a missing column. 

### Description
- Reworked the category join in `controllers/admin/AdminEverpsBlogPostController.php` to remove `acl.id_shop` from the `ever_blog_category_lang` join and instead add a `LEFT JOIN` to `ever_blog_category_shop` (`acs`) on `id_ever_category` and the current shop id. 
- Kept the language filter on the `ever_blog_category_lang` join and preserved the existing `WHERE` conditions for `a.id_shop` and `l.id_lang`. 
- This change prevents the SQL error `Unknown column 'acl.id_shop' in 'on clause'` by using the proper shop mapping table. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cba0214ec832294617cfe299147a1)