### PR TITLE
Optimize blog post retrieval joins

### DIFF
--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -226,12 +226,12 @@ class EverPsBlogPost extends ObjectModel
             $sql = new DbQuery;
             $sql->select('*');
             $sql->from(self::$definition['table'] . '_lang', 'bpl');
-            $sql->leftJoin(
+            $sql->innerJoin(
                 self::$definition['table'],
                 'bp',
                 'bp.' . self::$definition['primary'] . ' = bpl.' . self::$definition['primary']
             );
-            $sql->leftJoin(
+            $sql->innerJoin(
                 self::$definition['table'] . '_shop',
                 'bps',
                 'bp.' . self::$definition['primary'] . ' = bps.' . self::$definition['primary']


### PR DESCRIPTION
### Motivation
- Replace `LEFT JOIN` with `INNER JOIN` in the blog post retrieval query to avoid scanning rows that will be filtered by the `WHERE` clauses and to improve index usage and query performance.

### Description
- Replaced two `leftJoin` calls with `innerJoin` in `classes/EverPsBlogPost.php` inside the `getPosts()` query so that `bp` and `bps` are joined only when matching rows exist.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d01eedf0832284911f19f814f62a)