### PR TITLE
Optimize PrettyBlocks post choice query with lightweight cached method

### DIFF
--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -321,6 +321,52 @@ class EverPsBlogPost extends ObjectModel
         return Cache::retrieve($cache_id);
     }
 
+    public static function getPostsForChoices(
+        $id_lang,
+        $id_shop,
+        $limit = 500,
+        $post_status = 'published'
+    ) {
+        $cache_id = 'EverPsBlogPost::getPostsForChoices_'
+        . (int) $id_lang
+        . '_'
+        . (int) $id_shop
+        . '_'
+        . (int) $limit
+        . '_'
+        . $post_status;
+
+        if (!Cache::isStored($cache_id)) {
+            $limit = (int) $limit;
+            if ($limit <= 0) {
+                $limit = 500;
+            }
+
+            $sql = new DbQuery;
+            $sql->select('bp.' . self::$definition['primary'] . ', bpl.title');
+            $sql->from(self::$definition['table'] . '_lang', 'bpl');
+            $sql->innerJoin(
+                self::$definition['table'],
+                'bp',
+                'bp.' . self::$definition['primary'] . ' = bpl.' . self::$definition['primary']
+            );
+            $sql->innerJoin(
+                self::$definition['table'] . '_shop',
+                'bps',
+                'bp.' . self::$definition['primary'] . ' = bps.' . self::$definition['primary']
+                . ' AND bps.id_shop = ' . (int) $id_shop
+            );
+            $sql->where('bp.post_status = "' . pSQL($post_status) . '"');
+            $sql->where('bpl.id_lang = ' . (int) $id_lang);
+            $sql->orderBy('bp.date_add desc');
+            $sql->limit($limit);
+
+            Cache::store($cache_id, Db::getInstance()->executeS($sql));
+        }
+
+        return Cache::retrieve($cache_id);
+    }
+
     /**
      * Get latest posts
      * @param int id_lang, int id_shop, int start query, int limit query, string post_status

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -4758,10 +4758,9 @@ class EverPsBlog extends Module
     private function getPrettyBlocksPostChoices()
     {
         $choices = [];
-        $posts = EverPsBlogPost::getPosts(
+        $posts = EverPsBlogPost::getPostsForChoices(
             (int) $this->context->language->id,
             (int) $this->context->shop->id,
-            0,
             500,
             'published'
         );


### PR DESCRIPTION
### Motivation
- The PrettyBlocks post choices were loading full `SELECT *` results for up to 500 posts which is costly according to profiler traces and can degrade performance when rendering blocks. 
- Introduce a lightweight, cached query that only fetches the fields needed for selection lists to reduce query cost and memory usage.

### Description
- Add `EverPsBlogPost::getPostsForChoices($id_lang, $id_shop, $limit = 500, $post_status = 'published')` which executes a minimal `DbQuery` selecting only the primary id and `bpl.title`, applies shop and language joins, orders by `date_add` and caches the result. 
- Replace the previous call to `EverPsBlogPost::getPosts(...)` inside `getPrettyBlocksPostChoices()` in `everpsblog.php` with the new `getPostsForChoices()` to rely on the lightweight query and caching. 
- Default limit is 500 and a cache key is used to avoid repeated expensive queries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d1cc09bc8322b7de28b4a5f06cb3)