### PR TITLE
feat(admin): migrate BO tabs to Symfony routes with legacy redirection bridge

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -1,0 +1,34 @@
+everpsblog_admin_post:
+  path: /everpsblog/post
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\\Module\\Everpsblog\\Controller\\Admin\\PostController::indexAction'
+    _legacy_controller: AdminEverPsBlogPost
+
+everpsblog_admin_category:
+  path: /everpsblog/category
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\\Module\\Everpsblog\\Controller\\Admin\\CategoryController::indexAction'
+    _legacy_controller: AdminEverPsBlogCategory
+
+everpsblog_admin_tag:
+  path: /everpsblog/tag
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\\Module\\Everpsblog\\Controller\\Admin\\TagController::indexAction'
+    _legacy_controller: AdminEverPsBlogTag
+
+everpsblog_admin_author:
+  path: /everpsblog/author
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\\Module\\Everpsblog\\Controller\\Admin\\AuthorController::indexAction'
+    _legacy_controller: AdminEverPsBlogAuthor
+
+everpsblog_admin_comment:
+  path: /everpsblog/comment
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\\Module\\Everpsblog\\Controller\\Admin\\CommentController::indexAction'
+    _legacy_controller: AdminEverPsBlogComment

--- a/controllers/admin/EverPsBlogAdminController.php
+++ b/controllers/admin/EverPsBlogAdminController.php
@@ -9,6 +9,13 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
     protected $shop_url;
     protected $img_url;
     protected $html;
+    protected $legacyToSymfonyRoutes = [
+        'AdminEverPsBlogPost' => 'everpsblog_admin_post',
+        'AdminEverPsBlogCategory' => 'everpsblog_admin_category',
+        'AdminEverPsBlogTag' => 'everpsblog_admin_tag',
+        'AdminEverPsBlogComment' => 'everpsblog_admin_comment',
+        'AdminEverPsBlogAuthor' => 'everpsblog_admin_author',
+    ];
 
     public function __construct()
     {
@@ -20,14 +27,45 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
         $this->assignCommonVars();
     }
 
+    public function init()
+    {
+        $this->redirectToSymfonyRouteIfNeeded();
+        parent::init();
+    }
+
+    protected function redirectToSymfonyRouteIfNeeded()
+    {
+        if ((bool) Tools::getValue('legacy_proxy')) {
+            return;
+        }
+
+        $controllerName = Tools::getValue('controller');
+        if (!$controllerName || !isset($this->legacyToSymfonyRoutes[$controllerName])) {
+            return;
+        }
+
+        $queryParameters = $_GET;
+        unset($queryParameters['controller'], $queryParameters['token']);
+        $queryParameters['legacy_redirect'] = 1;
+
+        $url = $this->context->link->getAdminLink(
+            $this->legacyToSymfonyRoutes[$controllerName],
+            true,
+            [],
+            $queryParameters
+        );
+
+        Tools::redirectAdmin($url);
+    }
+
     protected function assignCommonVars()
     {
         $moduleConfUrl = 'index.php?controller=AdminModules&configure=' . $this->module_name . '&token=' . Tools::getAdminTokenLite('AdminModules');
-        $postUrl = 'index.php?controller=AdminEverPsBlogPost&token=' . Tools::getAdminTokenLite('AdminEverPsBlogPost');
-        $authorUrl = 'index.php?controller=AdminEverPsBlogAuthor&token=' . Tools::getAdminTokenLite('AdminEverPsBlogAuthor');
-        $categoryUrl = 'index.php?controller=AdminEverPsBlogCategory&token=' . Tools::getAdminTokenLite('AdminEverPsBlogCategory');
-        $tagUrl = 'index.php?controller=AdminEverPsBlogTag&token=' . Tools::getAdminTokenLite('AdminEverPsBlogTag');
-        $commentUrl = 'index.php?controller=AdminEverPsBlogComment&token=' . Tools::getAdminTokenLite('AdminEverPsBlogComment');
+        $postUrl = $this->context->link->getAdminLink('everpsblog_admin_post');
+        $authorUrl = $this->context->link->getAdminLink('everpsblog_admin_author');
+        $categoryUrl = $this->context->link->getAdminLink('everpsblog_admin_category');
+        $tagUrl = $this->context->link->getAdminLink('everpsblog_admin_tag');
+        $commentUrl = $this->context->link->getAdminLink('everpsblog_admin_comment');
         $blogUrl = $this->context->link->getModuleLink($this->module_name, 'blog', [], true);
         $ever_blog_token = Tools::encrypt('everpsblog/cron');
         $emptytrash = $this->context->link->getModuleLink(
@@ -96,27 +134,27 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
             'icon' => 'process-icon-cogs',
         ];
         $this->page_header_toolbar_btn['posts'] = [
-            'href' => 'index.php?controller=AdminEverPsBlogPost&token=' . Tools::getAdminTokenLite('AdminEverPsBlogPost'),
+            'href' => $this->context->link->getAdminLink('everpsblog_admin_post'),
             'desc' => $this->l('Posts'),
             'icon' => 'process-icon-list',
         ];
         $this->page_header_toolbar_btn['categories'] = [
-            'href' => 'index.php?controller=AdminEverPsBlogCategory&token=' . Tools::getAdminTokenLite('AdminEverPsBlogCategory'),
+            'href' => $this->context->link->getAdminLink('everpsblog_admin_category'),
             'desc' => $this->l('Categories'),
             'icon' => 'process-icon-categories',
         ];
         $this->page_header_toolbar_btn['tags'] = [
-            'href' => 'index.php?controller=AdminEverPsBlogTag&token=' . Tools::getAdminTokenLite('AdminEverPsBlogTag'),
+            'href' => $this->context->link->getAdminLink('everpsblog_admin_tag'),
             'desc' => $this->l('Tags'),
             'icon' => 'process-icon-tag',
         ];
         $this->page_header_toolbar_btn['comments'] = [
-            'href' => 'index.php?controller=AdminEverPsBlogComment&token=' . Tools::getAdminTokenLite('AdminEverPsBlogComment'),
+            'href' => $this->context->link->getAdminLink('everpsblog_admin_comment'),
             'desc' => $this->l('Comments'),
             'icon' => 'process-icon-comments',
         ];
         $this->page_header_toolbar_btn['authors'] = [
-            'href' => 'index.php?controller=AdminEverPsBlogAuthor&token=' . Tools::getAdminTokenLite('AdminEverPsBlogAuthor'),
+            'href' => $this->context->link->getAdminLink('everpsblog_admin_author'),
             'desc' => $this->l('Authors'),
             'icon' => 'process-icon-user',
         ];

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -121,27 +121,27 @@ class EverPsBlog extends Module
                 $this->l('Blog')
             )
             && $this->installModuleTab(
-                'AdminEverPsBlogPost',
+                'everpsblog_admin_post',
                 'AdminEverPsBlog',
                 $this->l('Posts')
             )
             && $this->installModuleTab(
-                'AdminEverPsBlogCategory',
+                'everpsblog_admin_category',
                 'AdminEverPsBlog',
                 $this->l('Categories')
             )
             && $this->installModuleTab(
-                'AdminEverPsBlogTag',
+                'everpsblog_admin_tag',
                 'AdminEverPsBlog',
                 $this->l('Tags')
             )
             && $this->installModuleTab(
-                'AdminEverPsBlogComment',
+                'everpsblog_admin_comment',
                 'AdminEverPsBlog',
                 $this->l('Comments')
             )
             && $this->installModuleTab(
-                'AdminEverPsBlogAuthor',
+                'everpsblog_admin_author',
                 'AdminEverPsBlog',
                 $this->l('Authors')
             )
@@ -194,11 +194,11 @@ class EverPsBlog extends Module
         Configuration::deleteByName('EVERBLOG_SHOW_POST_TAGS');
         return parent::uninstall()
             && $this->uninstallModuleTab('AdminEverPsBlog')
-            && $this->uninstallModuleTab('AdminEverPsBlogPost')
-            && $this->uninstallModuleTab('AdminEverPsBlogCategory')
-            && $this->uninstallModuleTab('AdminEverPsBlogTag')
-            && $this->uninstallModuleTab('AdminEverPsBlogComment')
-            && $this->uninstallModuleTab('AdminEverPsBlogAuthor');
+            && $this->uninstallModuleTab('everpsblog_admin_post')
+            && $this->uninstallModuleTab('everpsblog_admin_category')
+            && $this->uninstallModuleTab('everpsblog_admin_tag')
+            && $this->uninstallModuleTab('everpsblog_admin_comment')
+            && $this->uninstallModuleTab('everpsblog_admin_author');
     }
 
     private function installModuleTab($tabClass, $parent, $tabName)
@@ -641,31 +641,31 @@ class EverPsBlog extends Module
         );
         $quickLinks = [
             [
-                'href' => $this->context->link->getAdminLink('AdminEverPsBlogPost'),
+                'href' => $this->context->link->getAdminLink('everpsblog_admin_post'),
                 'label' => $this->l('Manage posts'),
                 'description' => $this->l('Create, edit or schedule blog articles'),
                 'icon' => 'icon-pencil',
             ],
             [
-                'href' => $this->context->link->getAdminLink('AdminEverPsBlogCategory'),
+                'href' => $this->context->link->getAdminLink('everpsblog_admin_category'),
                 'label' => $this->l('Organise categories'),
                 'description' => $this->l('Structure your content and improve navigation'),
                 'icon' => 'icon-folder-open',
             ],
             [
-                'href' => $this->context->link->getAdminLink('AdminEverPsBlogTag'),
+                'href' => $this->context->link->getAdminLink('everpsblog_admin_tag'),
                 'label' => $this->l('Curate tags'),
                 'description' => $this->l('Highlight related topics for your readers'),
                 'icon' => 'icon-tags',
             ],
             [
-                'href' => $this->context->link->getAdminLink('AdminEverPsBlogAuthor'),
+                'href' => $this->context->link->getAdminLink('everpsblog_admin_author'),
                 'label' => $this->l('Manage authors'),
                 'description' => $this->l('Keep contributor profiles up to date'),
                 'icon' => 'icon-user',
             ],
             [
-                'href' => $this->context->link->getAdminLink('AdminEverPsBlogComment'),
+                'href' => $this->context->link->getAdminLink('everpsblog_admin_comment'),
                 'label' => $this->l('Moderate comments'),
                 'description' => $this->l('Review community feedback in one place'),
                 'icon' => 'icon-comments',
@@ -2330,6 +2330,11 @@ class EverPsBlog extends Module
                 'AdminEverPsBlogAuthor',
                 'AdminEverPsBlogCategory',
                 'AdminEverPsBlogComment',
+                'everpsblog_admin_post',
+                'everpsblog_admin_tag',
+                'everpsblog_admin_author',
+                'everpsblog_admin_category',
+                'everpsblog_admin_comment',
             ];
             if (in_array(Tools::getValue('controller'), $blogAdminControllers)
                 || Tools::getValue('configure') == $this->name

--- a/src/Controller/Admin/AbstractDomainController.php
+++ b/src/Controller/Admin/AbstractDomainController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Context;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class AbstractDomainController
+{
+    protected function redirectToLegacyController(Request $request, string $legacyController): RedirectResponse
+    {
+        $queryParameters = $request->query->all();
+        unset($queryParameters['legacy_redirect']);
+        $queryParameters['legacy_proxy'] = 1;
+
+        $legacyUrl = Context::getContext()->link->getAdminLink(
+            $legacyController,
+            true,
+            [],
+            $queryParameters
+        );
+
+        return new RedirectResponse($legacyUrl, RedirectResponse::HTTP_FOUND);
+    }
+}

--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class AuthorController extends AbstractDomainController
+{
+    public function indexAction(Request $request): RedirectResponse
+    {
+        return $this->redirectToLegacyController($request, 'AdminEverPsBlogAuthor');
+    }
+}

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class CategoryController extends AbstractDomainController
+{
+    public function indexAction(Request $request): RedirectResponse
+    {
+        return $this->redirectToLegacyController($request, 'AdminEverPsBlogCategory');
+    }
+}

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class CommentController extends AbstractDomainController
+{
+    public function indexAction(Request $request): RedirectResponse
+    {
+        return $this->redirectToLegacyController($request, 'AdminEverPsBlogComment');
+    }
+}

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class PostController extends AbstractDomainController
+{
+    public function indexAction(Request $request): RedirectResponse
+    {
+        return $this->redirectToLegacyController($request, 'AdminEverPsBlogPost');
+    }
+}

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class TagController extends AbstractDomainController
+{
+    public function indexAction(Request $request): RedirectResponse
+    {
+        return $this->redirectToLegacyController($request, 'AdminEverPsBlogTag');
+    }
+}


### PR DESCRIPTION
### Motivation
- Modernise les points d'entrée Back Office en exposant des routes Symfony par domaine (Post, Category, Tag, Author, Comment). 
- Permettre une migration progressive sans casser les installations existantes en conservant la compatibilité avec les contrôleurs legacy. 
- Centraliser la logique de redirection pour éviter les boucles et préserver les paramètres de requête lors des transferts.

### Description
- Ajout de routes Symfony dans `config/routes.yml` pour `everpsblog_admin_post`, `everpsblog_admin_category`, `everpsblog_admin_tag`, `everpsblog_admin_author` et `everpsblog_admin_comment` qui pointent vers des contrôleurs dédiés et conservent le mapping `_legacy_controller`.
- Création de contrôleurs Symfony sous `src/Controller/Admin/` : `PostController`, `CategoryController`, `TagController`, `AuthorController`, `CommentController` et d’un helper commun `AbstractDomainController` qui proxie actuellement vers les contrôleurs legacy tout en transférant les query params et en ajoutant un marqueur `legacy_proxy`.
- Mise à jour de `everpsblog.php` pour installer/désinstaller les tabs en utilisant les identifiants de route Symfony (`everpsblog_admin_*`) et alignement des quick-links/URLs admin vers `everpsblog_admin_*`.
- Ajout d’une logique dans `controllers/admin/EverPsBlogAdminController.php` pour rediriger automatiquement les anciens contrôleurs legacy vers les nouvelles routes Symfony (avec protection `legacy_proxy` pour éviter les boucles) et adaptation des liens/toolbars pour pointer vers les routes Symfony.
- Extension de la liste allowlist TinyMCE dans le hook admin pour inclure les nouveaux identifiants de routes Symfony.

### Testing
- Vérification de la syntaxe PHP de `everpsblog.php` avec `php -l everpsblog.php` — succès.
- Vérification de la syntaxe PHP pour les fichiers modifiés/créés `controllers/admin/EverPsBlogAdminController.php`, `src/Controller/Admin/AbstractDomainController.php`, `src/Controller/Admin/PostController.php`, `src/Controller/Admin/CategoryController.php`, `src/Controller/Admin/TagController.php`, `src/Controller/Admin/AuthorController.php` et `src/Controller/Admin/CommentController.php` avec `php -l` — toutes les vérifications ont réussi.
- Aucune suite de tests automatisés additionnelle fournie dans ce changement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4e5d66748322b4de2a0c66c30cb2)