### PR TITLE
feat(doctrine): add blog entities and repositories for multilang + multishop mapping

### DIFF
--- a/src/Entity/Author.php
+++ b/src/Entity/Author.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\AuthorRepository")
+ * @ORM\Table(name="ever_blog_author")
+ */
+class Author
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_author", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="id_employee", type="integer") */
+    private $employeeId;
+
+    /** @ORM\Column(name="nickhandle", type="string", length=255) */
+    private $nickhandle;
+
+    /** @ORM\Column(name="active", type="boolean", nullable=true) */
+    private $active;
+}

--- a/src/Entity/AuthorLang.php
+++ b/src/Entity/AuthorLang.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_author_lang") */
+class AuthorLang
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_author", type="integer") */
+    private $authorId;
+
+    /** @ORM\Id @ORM\Column(name="id_lang", type="integer") */
+    private $langId;
+
+    /** @ORM\Column(name="meta_title", type="string", length=255, nullable=true) */
+    private $metaTitle;
+
+    /** @ORM\Column(name="link_rewrite", type="string", length=255, nullable=true) */
+    private $linkRewrite;
+
+    /** @ORM\Column(name="content", type="text") */
+    private $content;
+}

--- a/src/Entity/AuthorProduct.php
+++ b/src/Entity/AuthorProduct.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_author_product") */
+class AuthorProduct
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_author", type="integer") */
+    private $authorId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_author_product", type="integer") */
+    private $productId;
+}

--- a/src/Entity/AuthorShop.php
+++ b/src/Entity/AuthorShop.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_author_shop") */
+class AuthorShop
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_author", type="integer") */
+    private $authorId;
+
+    /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
+    private $shopId;
+}

--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\CategoryRepository")
+ * @ORM\Table(name="ever_blog_category")
+ */
+class Category
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_category", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="id_parent_category", type="integer", nullable=true) */
+    private $parentId;
+
+    /** @ORM\Column(name="active", type="boolean", nullable=true) */
+    private $active;
+
+    /** @ORM\Column(name="indexable", type="boolean", nullable=true) */
+    private $indexable;
+
+    /** @ORM\Column(name="follow", type="boolean", nullable=true) */
+    private $follow;
+
+    /** @ORM\Column(name="sitemap", type="boolean", options={"default": 1}) */
+    private $sitemap = true;
+
+    /** @ORM\Column(name="is_root_category", type="boolean", nullable=true) */
+    private $rootCategory;
+
+    /** @ORM\Column(name="count", type="integer", options={"default": 0}) */
+    private $count = 0;
+
+    /** @ORM\Column(name="allowed_groups", type="string", length=255, nullable=true) */
+    private $allowedGroups;
+
+    /** @ORM\Column(name="groups", type="text", nullable=true) */
+    private $groups;
+
+    /** @ORM\Column(name="date_add", type="datetime", nullable=true) */
+    private $createdAt;
+
+    /** @ORM\Column(name="date_upd", type="datetime", nullable=true) */
+    private $updatedAt;
+}

--- a/src/Entity/CategoryLang.php
+++ b/src/Entity/CategoryLang.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_category_lang") */
+class CategoryLang
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_category", type="integer") */
+    private $categoryId;
+
+    /** @ORM\Id @ORM\Column(name="id_lang", type="integer") */
+    private $langId;
+
+    /** @ORM\Column(name="title", type="string", length=255) */
+    private $title;
+
+    /** @ORM\Column(name="meta_title", type="string", length=255, nullable=true) */
+    private $metaTitle;
+
+    /** @ORM\Column(name="meta_description", type="string", length=255, nullable=true) */
+    private $metaDescription;
+
+    /** @ORM\Column(name="link_rewrite", type="string", length=255, nullable=true) */
+    private $linkRewrite;
+
+    /** @ORM\Column(name="content", type="text") */
+    private $content;
+
+    /** @ORM\Column(name="bottom_content", type="text", nullable=true) */
+    private $bottomContent;
+}

--- a/src/Entity/CategoryProduct.php
+++ b/src/Entity/CategoryProduct.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_category_product") */
+class CategoryProduct
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_category", type="integer") */
+    private $categoryId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_category_product", type="integer") */
+    private $productId;
+}

--- a/src/Entity/CategoryShop.php
+++ b/src/Entity/CategoryShop.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_category_shop") */
+class CategoryShop
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_category", type="integer") */
+    private $categoryId;
+
+    /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
+    private $shopId;
+}

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\CommentRepository")
+ * @ORM\Table(name="ever_blog_comments")
+ */
+class Comment
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_comment", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Column(name="id_lang", type="integer") */
+    private $langId;
+
+    /** @ORM\Column(name="comment", type="text") */
+    private $comment;
+
+    /** @ORM\Column(name="user_email", type="text") */
+    private $userEmail;
+
+    /** @ORM\Column(name="active", type="boolean", nullable=true) */
+    private $active;
+}

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\ImageRepository")
+ * @ORM\Table(name="ever_blog_image")
+ */
+class Image
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_image", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="image_type", type="string", length=255, nullable=true) */
+    private $type;
+
+    /** @ORM\Column(name="image_link", type="string", length=255, nullable=true) */
+    private $link;
+
+    /** @ORM\Column(name="id_element", type="integer") */
+    private $elementId;
+}

--- a/src/Entity/ImageShop.php
+++ b/src/Entity/ImageShop.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_image_shop") */
+class ImageShop
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_image", type="integer") */
+    private $imageId;
+
+    /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
+    private $shopId;
+}

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\PostRepository")
+ * @ORM\Table(name="ever_blog_post")
+ */
+class Post
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_post", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="id_author", type="integer") */
+    private $authorId;
+
+    /** @ORM\Column(name="id_default_category", type="integer") */
+    private $defaultCategoryId;
+
+    /** @ORM\Column(name="post_status", type="string", length=255) */
+    private $status;
+
+    /** @ORM\Column(name="active", type="boolean", nullable=true) */
+    private $active;
+
+    /** @ORM\Column(name="indexable", type="boolean", nullable=true) */
+    private $indexable;
+
+    /** @ORM\Column(name="follow", type="boolean", nullable=true) */
+    private $follow;
+
+    /** @ORM\Column(name="sitemap", type="boolean", options={"default": 1}) */
+    private $sitemap = true;
+
+    /** @ORM\Column(name="psswd", type="string", length=255, nullable=true) */
+    private $password;
+
+    /** @ORM\Column(name="starred", type="integer", options={"default": 0}) */
+    private $starred = 0;
+
+    /** @ORM\Column(name="count", type="integer", options={"default": 0}) */
+    private $viewCount = 0;
+
+    /** @ORM\Column(name="allowed_groups", type="string", length=255, nullable=true) */
+    private $allowedGroups;
+
+    /** @ORM\Column(name="groups", type="text", nullable=true) */
+    private $groups;
+
+    /** @ORM\Column(name="date_add", type="datetime", nullable=true) */
+    private $createdAt;
+
+    /** @ORM\Column(name="date_upd", type="datetime", nullable=true) */
+    private $updatedAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+}

--- a/src/Entity/PostCategory.php
+++ b/src/Entity/PostCategory.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_post_category") */
+class PostCategory
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_post_category", type="integer") */
+    private $categoryId;
+}

--- a/src/Entity/PostLang.php
+++ b/src/Entity/PostLang.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="ever_blog_post_lang")
+ */
+class PostLang
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Id @ORM\Column(name="id_lang", type="integer") */
+    private $langId;
+
+    /** @ORM\Column(name="title", type="string", length=255) */
+    private $title;
+
+    /** @ORM\Column(name="meta_title", type="string", length=255, nullable=true) */
+    private $metaTitle;
+
+    /** @ORM\Column(name="meta_description", type="string", length=255, nullable=true) */
+    private $metaDescription;
+
+    /** @ORM\Column(name="link_rewrite", type="string", length=255, nullable=true) */
+    private $linkRewrite;
+
+    /** @ORM\Column(name="content", type="text") */
+    private $content;
+
+    /** @ORM\Column(name="excerpt", type="string", length=255, nullable=true) */
+    private $excerpt;
+}

--- a/src/Entity/PostProduct.php
+++ b/src/Entity/PostProduct.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_post_product") */
+class PostProduct
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_post_product", type="integer") */
+    private $productId;
+}

--- a/src/Entity/PostShop.php
+++ b/src/Entity/PostShop.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="ever_blog_post_shop")
+ */
+class PostShop
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
+    private $shopId;
+}

--- a/src/Entity/PostTag.php
+++ b/src/Entity/PostTag.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_post_tag") */
+class PostTag
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_post", type="integer") */
+    private $postId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_post_tag", type="integer") */
+    private $tagId;
+}

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\TagRepository")
+ * @ORM\Table(name="ever_blog_tag")
+ */
+class Tag
+{
+    /** @ORM\Id @ORM\GeneratedValue @ORM\Column(name="id_ever_tag", type="integer") */
+    private $id;
+
+    /** @ORM\Column(name="active", type="boolean", nullable=true) */
+    private $active;
+
+    /** @ORM\Column(name="count", type="integer", options={"default": 0}) */
+    private $count = 0;
+}

--- a/src/Entity/TagLang.php
+++ b/src/Entity/TagLang.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_tag_lang") */
+class TagLang
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_tag", type="integer") */
+    private $tagId;
+
+    /** @ORM\Id @ORM\Column(name="id_lang", type="integer") */
+    private $langId;
+
+    /** @ORM\Column(name="title", type="string", length=255) */
+    private $title;
+
+    /** @ORM\Column(name="link_rewrite", type="string", length=255, nullable=true) */
+    private $linkRewrite;
+}

--- a/src/Entity/TagProduct.php
+++ b/src/Entity/TagProduct.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_tag_product") */
+class TagProduct
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_tag", type="integer") */
+    private $tagId;
+
+    /** @ORM\Id @ORM\Column(name="id_ever_tag_product", type="integer") */
+    private $productId;
+}

--- a/src/Entity/TagShop.php
+++ b/src/Entity/TagShop.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/** @ORM\Entity @ORM\Table(name="ever_blog_tag_shop") */
+class TagShop
+{
+    /** @ORM\Id @ORM\Column(name="id_ever_tag", type="integer") */
+    private $tagId;
+
+    /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
+    private $shopId;
+}

--- a/src/Repository/AuthorRepository.php
+++ b/src/Repository/AuthorRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class AuthorRepository extends EntityRepository
+{
+    public function findByShopAndLanguage($shopId, $langId)
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        return $qb->select('a, al')
+            ->from('PrestaShop\\Module\\Everpsblog\\Entity\\Author', 'a')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\AuthorLang', 'al', 'WITH', 'al.authorId = a.id')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\AuthorShop', 'ash', 'WITH', 'ash.authorId = a.id')
+            ->where('al.langId = :langId')
+            ->andWhere('ash.shopId = :shopId')
+            ->setParameter('langId', (int) $langId)
+            ->setParameter('shopId', (int) $shopId)
+            ->getQuery()
+            ->getArrayResult();
+    }
+}

--- a/src/Repository/CategoryRepository.php
+++ b/src/Repository/CategoryRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class CategoryRepository extends EntityRepository
+{
+    public function findByShopAndLanguage($shopId, $langId)
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        return $qb->select('c, cl')
+            ->from('PrestaShop\\Module\\Everpsblog\\Entity\\Category', 'c')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\CategoryLang', 'cl', 'WITH', 'cl.categoryId = c.id')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\CategoryShop', 'cs', 'WITH', 'cs.categoryId = c.id')
+            ->where('cl.langId = :langId')
+            ->andWhere('cs.shopId = :shopId')
+            ->setParameter('langId', (int) $langId)
+            ->setParameter('shopId', (int) $shopId)
+            ->getQuery()
+            ->getArrayResult();
+    }
+}

--- a/src/Repository/CommentRepository.php
+++ b/src/Repository/CommentRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class CommentRepository extends EntityRepository
+{
+    public function findByPostAndLanguage($postId, $langId)
+    {
+        return $this->createQueryBuilder('c')
+            ->where('c.postId = :postId')
+            ->andWhere('c.langId = :langId')
+            ->setParameter('postId', (int) $postId)
+            ->setParameter('langId', (int) $langId)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Repository/ImageRepository.php
+++ b/src/Repository/ImageRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class ImageRepository extends EntityRepository
+{
+    public function findOneForElement($elementId, $imageType)
+    {
+        return $this->createQueryBuilder('i')
+            ->where('i.elementId = :elementId')
+            ->andWhere('i.type = :type')
+            ->setParameter('elementId', (int) $elementId)
+            ->setParameter('type', (string) $imageType)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Repository/PostRepository.php
+++ b/src/Repository/PostRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class PostRepository extends EntityRepository
+{
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function findBackOfficeList($langId, $shopId, $limit = 50)
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        return $qb->select('p, pl')
+            ->from('PrestaShop\\Module\\Everpsblog\\Entity\\Post', 'p')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\PostLang', 'pl', 'WITH', 'pl.postId = p.id')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\PostShop', 'ps', 'WITH', 'ps.postId = p.id')
+            ->where('pl.langId = :langId')
+            ->andWhere('ps.shopId = :shopId')
+            ->setParameter('langId', (int) $langId)
+            ->setParameter('shopId', (int) $shopId)
+            ->setMaxResults((int) $limit)
+            ->getQuery()
+            ->getArrayResult();
+    }
+}

--- a/src/Repository/TagRepository.php
+++ b/src/Repository/TagRepository.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Repository;
+
+use Doctrine\ORM\EntityRepository;
+
+class TagRepository extends EntityRepository
+{
+    public function findByShopAndLanguage($shopId, $langId)
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+
+        return $qb->select('t, tl')
+            ->from('PrestaShop\\Module\\Everpsblog\\Entity\\Tag', 't')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\TagLang', 'tl', 'WITH', 'tl.tagId = t.id')
+            ->innerJoin('PrestaShop\\Module\\Everpsblog\\Entity\\TagShop', 'ts', 'WITH', 'ts.tagId = t.id')
+            ->where('tl.langId = :langId')
+            ->andWhere('ts.shopId = :shopId')
+            ->setParameter('langId', (int) $langId)
+            ->setParameter('shopId', (int) $shopId)
+            ->getQuery()
+            ->getArrayResult();
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a proper Doctrine data model for the blog domain to align ORM mapping with existing SQL tables.  
- Replace redundant JSON-encoded fields with explicit multilingual (`*_lang`) and multishop (`*_shop`) entities to simplify localized and shop-scoped queries.  
- Prepare a foundation to progressively replace `ObjectModel` usage in BO CRUD flows with repository-based access.  

### Description
- Add Doctrine entities under `src/Entity/` for core models: `Post`, `Category`, `Tag`, `Author`, `Comment`, `Image`.  
- Add dedicated multilingual and multishop entities: `PostLang`, `PostShop`, `CategoryLang`, `CategoryShop`, `TagLang`, `TagShop`, `AuthorLang`, `AuthorShop`, `ImageShop`.  
- Add explicit association/link entities for relational tables: `PostCategory`, `PostTag`, `PostProduct`, `CategoryProduct`, `TagProduct`, `AuthorProduct`.  
- Add repositories under `src/Repository/` with helper queries to bootstrap BO/domain access: `PostRepository` (`findBackOfficeList`), `CategoryRepository` / `TagRepository` / `AuthorRepository` (`findByShopAndLanguage`), `CommentRepository` (`findByPostAndLanguage`) and `ImageRepository` (`findOneForElement`).  
- No legacy controller or runtime behavior was changed in this PR; this is an ORM and repository foundation only.  

### Testing
- Ran PHP syntax checks for all created files using `php -l` for each file and all checks passed.  
- Committed the new files successfully (`git commit`) and prepared the PR with the included description.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df4ff7eca88322a7a88f4b6a5d0493)