### PR TITLE
Migrate taxonomy JSON to relational tables, add integrity checks and BO indexes (v6.0.4)

### DIFF
--- a/classes/EverPsBlogPost.php
+++ b/classes/EverPsBlogPost.php
@@ -1180,32 +1180,7 @@ class EverPsBlogPost extends ObjectModel
         . '_'
         . (bool) $starred;
         if (!Cache::isStored($cache_id)) {
-            $sql = new DbQuery();
-            $sql->select('post_categories');
-            $sql->from(self::$definition['table'], 'ep');
-            $sql->leftJoin(
-                self::$definition['table'] . '_lang',
-                'bpl',
-                'ep.' . self::$definition['primary'] . ' = bpl.' . self::$definition['primary'] . ''
-            );
-            $sql->where(
-                'ep.' . self::$definition['primary'] . ' = ' . (int) $id_ever_post
-            );
-            $sql->where(
-                'ep.id_shop = ' . (int) $id_shop
-            );
-            $sql->where(
-                'ep.id_lang = ' . (int) $id_lang
-            );
-            $sql->where(
-                'ep.active = ' . (int) $active
-            );
-            if ((bool) $starred === true) {
-                $sql->where('bp.starred = 1');
-            }
-            $sql->orderBy('ep.date_add DESC');
-            $post_categories = Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
-            $return = json_decode($post_categories);
+            $return = EverPsBlogTaxonomy::getPostCategoriesTaxonomies((int) $id_ever_post);
             Cache::store($cache_id, $return);
             return $return;
         }

--- a/classes/EverPsBlogTaxonomy.php
+++ b/classes/EverPsBlogTaxonomy.php
@@ -59,6 +59,7 @@ class EverPsBlogTaxonomy extends ObjectModel
             && !empty($table)
             && isset($key)
             && !empty($key)
+            && self::postExists((int) $id_post)
             && self::taxonomyExists($id_obj, $obj_name)
         ) {
             set_time_limit(0);
@@ -77,6 +78,22 @@ class EverPsBlogTaxonomy extends ObjectModel
                 return true;
             }
         }
+    }
+
+    /**
+     * Check if post exists to avoid orphan taxonomies
+     *
+     * @param int $id_post
+     * @return bool
+     */
+    protected static function postExists($id_post)
+    {
+        $sql = new DbQuery();
+        $sql->select('id_ever_post');
+        $sql->from('ever_blog_post');
+        $sql->where('id_ever_post = ' . (int) $id_post);
+
+        return (bool) Db::getInstance()->getValue($sql);
     }
 
     /**
@@ -457,40 +474,47 @@ class EverPsBlogTaxonomy extends ObjectModel
     {
         set_time_limit(0);
         $sql = new DbQuery;
-        $sql->select('*');
+        $sql->select('id_ever_post, id_default_category, post_categories, post_tags, post_products');
         $sql->from('ever_blog_post');
         $posts = Db::getInstance()->executeS($sql);
         foreach ($posts as $post_array) {
-            $post = new EverPsBlogPost(
-                (int) $post_array['id_ever_post']
-            );
-            $post_categories = json_decode(
-                $post->post_categories
-            );
+            $id_post = (int) $post_array['id_ever_post'];
+            $post_categories = json_decode((string) $post_array['post_categories'], true);
+            if (!is_array($post_categories)) {
+                $post_categories = [];
+            }
+            if ((int) $post_array['id_default_category'] > 0) {
+                $post_categories[] = (int) $post_array['id_default_category'];
+            }
+            $post_categories = array_unique(array_map('intval', $post_categories));
             foreach ($post_categories as $post_category) {
                 self::insertTaxonomy(
                     (int) $post_category,
-                    (int) $post->id,
+                    $id_post,
                     'category'
                 );
             }
-            $post_tags = json_decode(
-                $post->post_tags
-            );
+            $post_tags = json_decode((string) $post_array['post_tags'], true);
+            if (!is_array($post_tags)) {
+                $post_tags = [];
+            }
+            $post_tags = array_unique(array_map('intval', $post_tags));
             foreach ($post_tags as $post_tag) {
                 self::insertTaxonomy(
                     (int) $post_tag,
-                    (int) $post->id,
+                    $id_post,
                     'tag'
                 );
             }
-            $post_products = json_decode(
-                $post->post_products
-            );
+            $post_products = json_decode((string) $post_array['post_products'], true);
+            if (!is_array($post_products)) {
+                $post_products = [];
+            }
+            $post_products = array_unique(array_map('intval', $post_products));
             foreach ($post_products as $post_product) {
                 self::insertTaxonomy(
                     (int) $post_product,
-                    (int) $post->id,
+                    $id_post,
                     'product'
                 );
             }

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -46,7 +46,7 @@ class EverPsBlog extends Module
     {
         $this->name = 'everpsblog';
         $this->tab = 'front_office_features';
-        $this->version = '6.0.3';
+        $this->version = '6.0.4';
         $this->author = 'Team Ever';
         $this->need_instance = 0;
         $this->bootstrap = true;

--- a/install/install.php
+++ b/install/install.php
@@ -44,7 +44,10 @@ $sql[] =
         `starred` int(10) unsigned DEFAULT 0,
         `count` int(10) unsigned DEFAULT 0,
         `groups` text DEFAULT NULL,
-        PRIMARY KEY (`id_ever_post`)
+        PRIMARY KEY (`id_ever_post`),
+        KEY `idx_ever_blog_post_shop_status` (`id_shop`, `post_status`, `active`, `date_add`),
+        KEY `idx_ever_blog_post_author` (`id_author`),
+        KEY `idx_ever_blog_post_default_category` (`id_default_category`)
     ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
 
 $sql[] =
@@ -153,7 +156,8 @@ $sql[] =
         `date_add` DATETIME DEFAULT NULL,
         `date_upd` DATETIME DEFAULT NULL,
         `active` int(10) DEFAULT NULL,
-        PRIMARY KEY (`id_ever_comment`)
+        PRIMARY KEY (`id_ever_comment`),
+        KEY `idx_ever_blog_comment_post_lang` (`id_ever_post`, `id_lang`, `active`, `date_add`)
     ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
 
 $sql[] =
@@ -217,21 +221,24 @@ $sql[] =
     'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'ever_blog_post_category` (
         `id_ever_post_category` int(10) NOT NULL,
         `id_ever_post` int(10) unsigned NOT NULL,
-        PRIMARY KEY (`id_ever_post`, `id_ever_post_category`)
+        PRIMARY KEY (`id_ever_post`, `id_ever_post_category`),
+        KEY `idx_ever_blog_post_category_reverse` (`id_ever_post_category`, `id_ever_post`)
     ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
 
 $sql[] =
     'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'ever_blog_post_tag` (
         `id_ever_post_tag` int(10) NOT NULL,
         `id_ever_post` int(10) unsigned NOT NULL,
-        PRIMARY KEY (`id_ever_post`, `id_ever_post_tag`)
+        PRIMARY KEY (`id_ever_post`, `id_ever_post_tag`),
+        KEY `idx_ever_blog_post_tag_reverse` (`id_ever_post_tag`, `id_ever_post`)
     ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
 
 $sql[] =
     'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'ever_blog_post_product` (
         `id_ever_post_product` int(10) NOT NULL,
         `id_ever_post` int(10) unsigned NOT NULL,
-        PRIMARY KEY (`id_ever_post`, `id_ever_post_product`)
+        PRIMARY KEY (`id_ever_post`, `id_ever_post_product`),
+        KEY `idx_ever_blog_post_product_reverse` (`id_ever_post_product`, `id_ever_post`)
     ) ENGINE='._MYSQL_ENGINE_.' DEFAULT CHARSET=utf8';
 
 $sql[] =

--- a/upgrade/upgrade-6.0.4.php
+++ b/upgrade/upgrade-6.0.4.php
@@ -1,0 +1,98 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_0_4()
+{
+    set_time_limit(0);
+    $result = true;
+    $db = Db::getInstance();
+
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post', 'idx_ever_blog_post_shop_status', '`id_shop`, `post_status`, `active`, `date_add`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post', 'idx_ever_blog_post_author', '`id_author`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post', 'idx_ever_blog_post_default_category', '`id_default_category`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_comments', 'idx_ever_blog_comment_post_lang', '`id_ever_post`, `id_lang`, `active`, `date_add`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post_category', 'idx_ever_blog_post_category_reverse', '`id_ever_post_category`, `id_ever_post`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post_tag', 'idx_ever_blog_post_tag_reverse', '`id_ever_post_tag`, `id_ever_post`');
+    $result &= (bool) everpsblogAddIndexIfMissing('ever_blog_post_product', 'idx_ever_blog_post_product_reverse', '`id_ever_post_product`, `id_ever_post`');
+
+    $posts = $db->executeS('SELECT id_ever_post, id_default_category, post_categories, post_tags, post_products FROM `' . _DB_PREFIX_ . 'ever_blog_post`');
+
+    foreach ($posts as $post) {
+        $idPost = (int) $post['id_ever_post'];
+
+        $categories = json_decode((string) $post['post_categories'], true);
+        if (!is_array($categories)) {
+            $categories = [];
+        }
+        if ((int) $post['id_default_category'] > 0) {
+            $categories[] = (int) $post['id_default_category'];
+        }
+        $categories = array_unique(array_filter(array_map('intval', $categories)));
+
+        foreach ($categories as $idCategory) {
+            $result &= (bool) $db->execute('INSERT IGNORE INTO `' . _DB_PREFIX_ . 'ever_blog_post_category` (`id_ever_post_category`, `id_ever_post`) VALUES (' . (int) $idCategory . ', ' . $idPost . ')');
+        }
+
+        $tags = json_decode((string) $post['post_tags'], true);
+        if (!is_array($tags)) {
+            $tags = [];
+        }
+        $tags = array_unique(array_filter(array_map('intval', $tags)));
+        foreach ($tags as $idTag) {
+            $result &= (bool) $db->execute('INSERT IGNORE INTO `' . _DB_PREFIX_ . 'ever_blog_post_tag` (`id_ever_post_tag`, `id_ever_post`) VALUES (' . (int) $idTag . ', ' . $idPost . ')');
+        }
+
+        $products = json_decode((string) $post['post_products'], true);
+        if (!is_array($products)) {
+            $products = [];
+        }
+        $products = array_unique(array_filter(array_map('intval', $products)));
+        foreach ($products as $idProduct) {
+            $result &= (bool) $db->execute('INSERT IGNORE INTO `' . _DB_PREFIX_ . 'ever_blog_post_product` (`id_ever_post_product`, `id_ever_post`) VALUES (' . (int) $idProduct . ', ' . $idPost . ')');
+        }
+    }
+
+    // Application-level integrity constraints (PrestaShop-friendly, no hard FK).
+    $result &= (bool) $db->execute('DELETE epc
+        FROM `' . _DB_PREFIX_ . 'ever_blog_post_category` epc
+        LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_post` ep ON ep.id_ever_post = epc.id_ever_post
+        LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_category` ec ON ec.id_ever_category = epc.id_ever_post_category
+        WHERE ep.id_ever_post IS NULL OR ec.id_ever_category IS NULL');
+
+    $result &= (bool) $db->execute('DELETE ept
+        FROM `' . _DB_PREFIX_ . 'ever_blog_post_tag` ept
+        LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_post` ep ON ep.id_ever_post = ept.id_ever_post
+        LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_tag` et ON et.id_ever_tag = ept.id_ever_post_tag
+        WHERE ep.id_ever_post IS NULL OR et.id_ever_tag IS NULL');
+
+    $result &= (bool) $db->execute('DELETE epp
+        FROM `' . _DB_PREFIX_ . 'ever_blog_post_product` epp
+        LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_post` ep ON ep.id_ever_post = epp.id_ever_post
+        LEFT JOIN `' . _DB_PREFIX_ . 'product` p ON p.id_product = epp.id_ever_post_product
+        WHERE ep.id_ever_post IS NULL OR p.id_product IS NULL');
+
+    // Progressive deprecation marker for redundant JSON columns.
+    $result &= (bool) Configuration::updateValue('EVERBLOG_POST_JSON_DEPRECATED', 1);
+
+    return (bool) $result;
+}
+
+function everpsblogAddIndexIfMissing($table, $indexName, $fields)
+{
+    $indexExists = (bool) Db::getInstance()->getValue(
+        'SELECT 1 FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = "' . pSQL(_DB_PREFIX_ . $table) . '"
+        AND INDEX_NAME = "' . pSQL($indexName) . '"'
+    );
+
+    if ($indexExists) {
+        return true;
+    }
+
+    return Db::getInstance()->execute(
+        'ALTER TABLE `' . _DB_PREFIX_ . bqSQL($table) . '` ADD INDEX `' . bqSQL($indexName) . '` (' . $fields . ')'
+    );
+}


### PR DESCRIPTION
### Motivation
- Consolidate a single source of truth by moving category/tag/product relations from redundant JSON columns into relational join tables and progressively deprecate the JSON fields. 
- Ensure data consistency and performance in the Back Office by adding indexes for common filters and preventing orphan relations where SQL FKs cannot be relied on in some PrestaShop environments.

### Description
- Add `upgrade/upgrade-6.0.4.php` which backfills missing `ever_blog_post_category`, `ever_blog_post_tag`, and `ever_blog_post_product` rows from legacy JSON columns, adds indexes if missing, removes orphan relation rows via application-level cleanup, and writes a deprecation marker `EVERBLOG_POST_JSON_DEPRECATED`.
- Harden taxonomy insertion by adding `postExists()` checks in `classes/EverPsBlogTaxonomy.php` and make `migrateJsonPostsData()` robust to malformed JSON and include the `id_default_category` when backfilling.
- Switch `EverPsBlogPost::getPostCategories()` to read categories from relational taxonomies via `EverPsBlogTaxonomy::getPostCategoriesTaxonomies()` instead of decoding the `post_categories` JSON column.
- Add BO-oriented indexes to fresh-install SQL in `install/install.php` for `ever_blog_post`, `ever_blog_comments` and reverse indexes on join tables, and bump module version to `6.0.4` in `everpsblog.php`.

### Testing
- Ran syntax checks with `php -l` on `classes/EverPsBlogTaxonomy.php`, `classes/EverPsBlogPost.php`, `upgrade/upgrade-6.0.4.php`, `install/install.php` and `everpsblog.php`, and all returned "No syntax errors detected". 
- The upgrade script and index-creation helper were included and validated for syntax; no automated integration or DB migration tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df57cf0fd48322b1d1382a91c42569)