### PR TITLE
Add BO authorization voters, CSRF protections and sensitive action auditing

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -112,6 +112,25 @@ services:
 
   PrestaShop\Module\Everpsblog\Service\AdminRouteSigner: ~
 
+
+  prestashop.module.everpsblog.security.permission_provider:
+    class: PrestaShop\Module\Everpsblog\Service\Security\BackOfficePermissionProvider
+
+  prestashop.module.everpsblog.security.resource_voter:
+    class: PrestaShop\Module\Everpsblog\Security\BlogResourceVoter
+    arguments:
+      - '@prestashop.module.everpsblog.security.permission_provider'
+    tags:
+      - { name: security.voter }
+
+  prestashop.module.everpsblog.audit.sensitive_action_logger:
+    class: PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger
+    arguments:
+      - '@logger'
+
+  PrestaShop\Module\Everpsblog\Service\Security\BackOfficePermissionProvider: '@prestashop.module.everpsblog.security.permission_provider'
+  PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger: '@prestashop.module.everpsblog.audit.sensitive_action_logger'
+
   prestashop.module.everpsblog.controller.admin.post:
     class: PrestaShop\Module\Everpsblog\Controller\Admin\PostController
     arguments:
@@ -121,6 +140,7 @@ services:
       - '@PrestaShop\Module\Everpsblog\Grid\Definition\PostGridDefinitionFactory'
       - '@PrestaShop\Module\Everpsblog\Grid\Data\PostGridDataFactory'
       - '@PrestaShop\Module\Everpsblog\Form\DataProvider\PostFormDataProvider'
+      - '@prestashop.module.everpsblog.audit.sensitive_action_logger'
     public: true
 
   prestashop.module.everpsblog.controller.admin.category:
@@ -176,3 +196,12 @@ services:
 
   PrestaShop\Module\Everpsblog\Application\Blog\:
     resource: '../src/Application/Blog/*'
+
+  PrestaShop\Module\Everpsblog\Security\:
+    resource: '../src/Security/*'
+
+  PrestaShop\Module\Everpsblog\Service\Security\:
+    resource: '../src/Service/Security/*'
+
+  PrestaShop\Module\Everpsblog\Service\Audit\:
+    resource: '../src/Service/Audit/*'

--- a/controllers/admin/AdminEverPsBlogAuthorController.php
+++ b/controllers/admin/AdminEverPsBlogAuthorController.php
@@ -822,7 +822,16 @@ class AdminEverPsBlogAuthorController extends EverPsBlogAdminController
                     $featured_image->image_type = 'author';
                     $featured_image->image_link = $author_img_link;
                     $featured_image->id_shop = (int) Context::getContext()->shop->id;
-                    return $featured_image->save();
+                    $saved = (bool) $featured_image->save();
+                    if ($saved) {
+                        $this->logSensitiveAction('bo_media_import', [
+                            'resource' => 'author',
+                            'author_id' => (int) $author->id,
+                            'filename' => (string) $_FILES['author_image']['name'],
+                        ]);
+                    }
+
+                    return $saved;
                 }
             } else {
                 $this->display = 'edit';

--- a/controllers/admin/AdminEverPsBlogCategoryController.php
+++ b/controllers/admin/AdminEverPsBlogCategoryController.php
@@ -765,7 +765,16 @@ class AdminEverPsBlogCategoryController extends EverPsBlogAdminController
                         $featured_image->image_type = 'category';
                         $featured_image->image_link = $category_img_link;
                         $featured_image->id_shop = (int) Context::getContext()->shop->id;
-                        return $featured_image->save();
+                        $saved = (bool) $featured_image->save();
+                        if ($saved) {
+                            $this->logSensitiveAction('bo_media_import', [
+                                'resource' => 'category',
+                                'categoryId' => (int) $categoryId,
+                                'filename' => (string) $_FILES['category_image']['name'],
+                            ]);
+                        }
+
+                        return $saved;
                     }
                 } catch (Exception $e) {
                     PrestaShopLogger::addLog($this->module->name . ' : admin category : ' . $e->getMessage());

--- a/controllers/admin/AdminEverpsBlogPostController.php
+++ b/controllers/admin/AdminEverpsBlogPostController.php
@@ -208,22 +208,21 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
             ],
         ];
         if (Tools::getIsset('deletePost'.$this->table)) {
-            $token = Tools::getValue('token');
-            $hasValidToken = (
-                (Tools::isSubmit('deletePost'.$this->table) && Tools::isSubmit('token'))
-                || $token
-            ) && $token === $this->token;
+            $submittedToken = (string) Tools::getValue('everpsblog_csrf_token');
+            $tokenId = 'everpsblog_post_delete_' . (int) Tools::getValue($this->identifier);
 
             if (!$this->access('delete')) {
                 $this->errors[] = $this->l('You do not have permission to delete this post.');
-            } elseif (!$hasValidToken) {
-                $this->errors[] = $this->l('Invalid security token, the post was not deleted.');
+            } elseif (!$this->isValidCsrfToken($tokenId, $submittedToken)) {
+                $this->errors[] = $this->l('Invalid CSRF token, the post was not deleted.');
             } else {
                 $everObj = new $this->className(
                     (int) Tools::getValue($this->identifier)
                 );
-                if (Validate::isLoadedObject($everObj)) {
-                    $everObj->delete();
+                if (Validate::isLoadedObject($everObj) && $everObj->delete()) {
+                    $this->logSensitiveAction('bo_post_delete', [
+                        'post_id' => (int) Tools::getValue($this->identifier),
+                    ]);
                 }
             }
         }
@@ -973,7 +972,16 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
                         $featured_image->image_type = 'post';
                         $featured_image->image_link = $post_img_link;
                         $featured_image->id_shop = (int) Context::getContext()->shop->id;
-                        return $featured_image->save();
+                        $saved = (bool) $featured_image->save();
+                        if ($saved) {
+                            $this->logSensitiveAction('bo_media_import', [
+                                'resource' => 'post',
+                                'post_id' => (int) $postId,
+                                'filename' => (string) $_FILES['post_image']['name'],
+                            ]);
+                        }
+
+                        return $saved;
                     }
                 } catch (Exception $e) {
                     PrestaShopLogger::addLog($e->getMessage());
@@ -996,6 +1004,7 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
         $drop_url .= '&id_ever_post='.$id_ever_post;
         $drop_url .= '&token=';
         $drop_url .= Tools::getAdminTokenLite('AdminEverPsBlogPost');
+        $drop_url .= '&everpsblog_csrf_token=' . $this->getCsrfToken('everpsblog_post_delete_' . (int) $id_ever_post);
         $this->context->smarty->assign([
             'href' => $drop_url,
             'confirm' => $this->l('Delete post ?'),
@@ -1110,7 +1119,13 @@ class AdminEverPsBlogPostController extends EverPsBlogAdminController
             $everObj->post_status = 'published';
             if (!$everObj->save()) {
                 $this->errors[] = $this->l('An error has occurred: Can\'t publish the current object');
+
+                continue;
             }
+
+            $this->logSensitiveAction('bo_bulk_publish', [
+                'post_id' => (int) $idEverObj,
+            ]);
         }
     }
 

--- a/controllers/admin/AdminEverpsBlogTagController.php
+++ b/controllers/admin/AdminEverpsBlogTagController.php
@@ -725,7 +725,16 @@ class AdminEverPsBlogTagController extends EverPsBlogAdminController
                         $featured_image->image_type = 'tag';
                         $featured_image->image_link = $tag_img_link;
                         $featured_image->id_shop = (int) Context::getContext()->shop->id;
-                        return $featured_image->save();
+                        $saved = (bool) $featured_image->save();
+                        if ($saved) {
+                            $this->logSensitiveAction('bo_media_import', [
+                                'resource' => 'tag',
+                                'tagId' => (int) $tagId,
+                                'filename' => (string) $_FILES['tag_image']['name'],
+                            ]);
+                        }
+
+                        return $saved;
                     }
                 } catch (Exception $e) {
                     PrestaShopLogger::addLog($e->getMessage());

--- a/controllers/admin/EverPsBlogAdminController.php
+++ b/controllers/admin/EverPsBlogAdminController.php
@@ -216,8 +216,63 @@ abstract class EverPsBlogAdminController extends ModuleAdminController
                     $this->l('An error has occurred: Can\'t delete the current object with ID %d'),
                     $idEverObj
                 );
+
+                continue;
             }
+
+            $this->logSensitiveAction('bo_bulk_delete', [
+                'resource' => $this->table,
+                'entity_id' => $idEverObj,
+            ]);
         }
+    }
+
+
+    protected function getCsrfToken(string $tokenId): string
+    {
+        try {
+            $tokenManager = \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance()->get('security.csrf.token_manager');
+
+            return $tokenManager->getToken($tokenId)->getValue();
+        } catch (Exception $exception) {
+            PrestaShopLogger::addLog($exception->getMessage());
+
+            return '';
+        }
+    }
+
+    protected function isValidCsrfToken(string $tokenId, string $token): bool
+    {
+        if (empty($token)) {
+            return false;
+        }
+
+        try {
+            $tokenManager = \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance()->get('security.csrf.token_manager');
+
+            return $tokenManager->isTokenValid(new \Symfony\Component\Security\Csrf\CsrfToken($tokenId, $token));
+        } catch (Exception $exception) {
+            PrestaShopLogger::addLog($exception->getMessage());
+
+            return false;
+        }
+    }
+
+    protected function logSensitiveAction(string $action, array $context = [])
+    {
+        $employeeId = (int) (Context::getContext()->employee->id ?? 0);
+        $shopId = (int) (Context::getContext()->shop->id ?? 0);
+
+        $message = sprintf(
+            '[everpsblog][sensitive_action] %s %s',
+            $action,
+            json_encode(array_merge([
+                'employee_id' => $employeeId,
+                'shop_id' => $shopId,
+            ], $context))
+        );
+
+        PrestaShopLogger::addLog($message, 1, null, 'EverPsBlog', 0, true);
     }
 
     protected function displayError($message, $description = false)

--- a/src/Controller/Admin/AbstractDomainController.php
+++ b/src/Controller/Admin/AbstractDomainController.php
@@ -24,4 +24,9 @@ abstract class AbstractDomainController extends FrameworkBundleAdminController
     {
         return $this->contextStateService->getLanguageId();
     }
+
+    protected function denyBlogAccess(string $permission, string $resource): void
+    {
+        $this->denyAccessUnlessGranted($permission, $resource);
+    }
 }

--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -6,6 +6,7 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\AuthorFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\AuthorType;
 use PrestaShop\Module\Everpsblog\Grid\Data\AuthorGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\AuthorGridDefinitionFactory;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +27,7 @@ class AuthorController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_AUTHOR);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -35,6 +37,8 @@ class AuthorController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $authorId = null): Response
     {
+        $this->denyBlogAccess($authorId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_AUTHOR);
+
         $form = $this->createForm(AuthorType::class, $this->formDataProvider->getData($authorId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -6,6 +6,7 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\CategoryFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CategoryType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CategoryGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CategoryGridDefinitionFactory;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +27,7 @@ class CategoryController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_CATEGORY);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -35,6 +37,8 @@ class CategoryController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $categoryId = null): Response
     {
+        $this->denyBlogAccess($categoryId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_CATEGORY);
+
         $form = $this->createForm(CategoryType::class, $this->formDataProvider->getData($categoryId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -6,6 +6,7 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\CommentFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CommentType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CommentGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CommentGridDefinitionFactory;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +27,7 @@ class CommentController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_COMMENT);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextLangId(), $request->query->all()),
@@ -35,6 +37,8 @@ class CommentController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $commentId = null): Response
     {
+        $this->denyBlogAccess($commentId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_COMMENT);
+
         $form = $this->createForm(CommentType::class, $this->formDataProvider->getData($commentId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -9,6 +9,8 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\PostFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\PostType;
 use PrestaShop\Module\Everpsblog\Grid\Data\PostGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\PostGridDefinitionFactory;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
+use PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,6 +22,7 @@ class PostController extends AbstractDomainController
     private $definitionFactory;
     private $dataFactory;
     private $formDataProvider;
+    private $sensitiveActionLogger;
 
     public function __construct(
         \PrestaShop\Module\Everpsblog\Service\ContextStateService $contextStateService,
@@ -27,7 +30,8 @@ class PostController extends AbstractDomainController
         PostCommandAssembler $commandAssembler,
         PostGridDefinitionFactory $definitionFactory,
         PostGridDataFactory $dataFactory,
-        PostFormDataProvider $formDataProvider
+        PostFormDataProvider $formDataProvider,
+        SensitiveActionLogger $sensitiveActionLogger
     ) {
         parent::__construct($contextStateService);
         $this->commandBus = $commandBus;
@@ -35,10 +39,13 @@ class PostController extends AbstractDomainController
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
+        $this->sensitiveActionLogger = $sensitiveActionLogger;
     }
 
     public function indexAction(Request $request): Response
     {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_POST);
+
         $definition = $this->definitionFactory->build();
         $data = $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all());
 
@@ -51,6 +58,8 @@ class PostController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $postId = null): Response
     {
+        $this->denyBlogAccess($postId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_POST);
+
         $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId));
         $form->handleRequest($request);
 
@@ -63,8 +72,10 @@ class PostController extends AbstractDomainController
 
     public function createAction(Request $request): JsonResponse
     {
-        $command = $this->commandAssembler->assembleCreate($request->request->all());
+        $this->denyBlogAccess(BlogPermission::CREATE, BlogPermission::RES_POST);
+        $this->validateCsrfToken($request, 'everpsblog_post_create');
 
+        $command = $this->commandAssembler->assembleCreate($request->request->all());
         $postId = $this->commandBus->handle($command);
 
         return new JsonResponse(['id_ever_post' => $postId], JsonResponse::HTTP_CREATED);
@@ -72,6 +83,9 @@ class PostController extends AbstractDomainController
 
     public function updateAction(int $postId, Request $request): JsonResponse
     {
+        $this->denyBlogAccess(BlogPermission::UPDATE, BlogPermission::RES_POST);
+        $this->validateCsrfToken($request, 'everpsblog_post_update_' . $postId);
+
         $command = $this->commandAssembler->assembleUpdate($postId, $request->request->all());
 
         $updatedPostId = $this->commandBus->handle($command);
@@ -79,10 +93,23 @@ class PostController extends AbstractDomainController
         return new JsonResponse(['id_ever_post' => $updatedPostId], JsonResponse::HTTP_OK);
     }
 
-    public function deleteAction(int $postId): JsonResponse
+    public function deleteAction(int $postId, Request $request): JsonResponse
     {
+        $this->denyBlogAccess(BlogPermission::DELETE, BlogPermission::RES_POST);
+        $this->validateCsrfToken($request, 'everpsblog_post_delete_' . $postId);
+
         $this->commandBus->handle(new DeletePostCommand($postId));
+        $this->sensitiveActionLogger->log('bo_post_delete', ['post_id' => $postId]);
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function validateCsrfToken(Request $request, string $tokenId): void
+    {
+        $token = (string) ($request->request->get('_csrf_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+
+        if (!$this->isCsrfTokenValid($tokenId, $token)) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
     }
 }

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -6,6 +6,7 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\TagFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\TagType;
 use PrestaShop\Module\Everpsblog\Grid\Data\TagGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\TagGridDefinitionFactory;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -26,6 +27,7 @@ class TagController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_TAG);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -35,6 +37,8 @@ class TagController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $tagId = null): Response
     {
+        $this->denyBlogAccess($tagId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_TAG);
+
         $form = $this->createForm(TagType::class, $this->formDataProvider->getData($tagId));
         $form->handleRequest($request);
 

--- a/src/Security/BlogPermission.php
+++ b/src/Security/BlogPermission.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Security;
+
+final class BlogPermission
+{
+    public const READ = 'EVERPSBLOG_READ';
+    public const CREATE = 'EVERPSBLOG_CREATE';
+    public const UPDATE = 'EVERPSBLOG_UPDATE';
+    public const DELETE = 'EVERPSBLOG_DELETE';
+    public const PUBLISH = 'EVERPSBLOG_PUBLISH';
+
+    public const RES_POST = 'post';
+    public const RES_CATEGORY = 'category';
+    public const RES_TAG = 'tag';
+    public const RES_AUTHOR = 'author';
+    public const RES_COMMENT = 'comment';
+}

--- a/src/Security/BlogResourceVoter.php
+++ b/src/Security/BlogResourceVoter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Security;
+
+use PrestaShop\Module\Everpsblog\Service\Security\BackOfficePermissionProvider;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+class BlogResourceVoter extends Voter
+{
+    /** @var BackOfficePermissionProvider */
+    private $permissionProvider;
+
+    public function __construct(BackOfficePermissionProvider $permissionProvider)
+    {
+        $this->permissionProvider = $permissionProvider;
+    }
+
+    protected function supports($attribute, $subject): bool
+    {
+        if (!is_string($subject)) {
+            return false;
+        }
+
+        return in_array($attribute, [
+            BlogPermission::READ,
+            BlogPermission::CREATE,
+            BlogPermission::UPDATE,
+            BlogPermission::DELETE,
+            BlogPermission::PUBLISH,
+        ], true);
+    }
+
+    /**
+     * @param string $attribute
+     * @param string $subject
+     */
+    protected function voteOnAttribute($attribute, $subject, TokenInterface $token): bool
+    {
+        return $this->permissionProvider->isGranted($subject, $attribute);
+    }
+}

--- a/src/Service/Audit/SensitiveActionLogger.php
+++ b/src/Service/Audit/SensitiveActionLogger.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Service\Audit;
+
+use Context;
+use PrestaShopLogger;
+use Psr\Log\LoggerInterface;
+
+class SensitiveActionLogger
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function log(string $action, array $context = []): void
+    {
+        $employeeId = (int) (Context::getContext()->employee->id ?? 0);
+        $shopId = (int) (Context::getContext()->shop->id ?? 0);
+
+        $normalizedContext = array_merge([
+            'employee_id' => $employeeId,
+            'shop_id' => $shopId,
+        ], $context);
+
+        $message = sprintf('[everpsblog][sensitive_action] %s %s', $action, json_encode($normalizedContext));
+        $this->logger->notice($message, $normalizedContext);
+        PrestaShopLogger::addLog($message, 1, null, 'EverPsBlog', 0, true);
+    }
+}

--- a/src/Service/Security/BackOfficePermissionProvider.php
+++ b/src/Service/Security/BackOfficePermissionProvider.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Service\Security;
+
+use Configuration;
+use Context;
+use Profile;
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
+use Tab;
+
+class BackOfficePermissionProvider
+{
+    private const CONFIG_KEY = 'EVERPSBLOG_PROFILE_PERMISSIONS';
+
+    private const RESOURCE_TAB_MAP = [
+        BlogPermission::RES_POST => 'AdminEverPsBlogPost',
+        BlogPermission::RES_CATEGORY => 'AdminEverPsBlogCategory',
+        BlogPermission::RES_TAG => 'AdminEverPsBlogTag',
+        BlogPermission::RES_AUTHOR => 'AdminEverPsBlogAuthor',
+        BlogPermission::RES_COMMENT => 'AdminEverPsBlogComment',
+    ];
+
+    public function isGranted(string $resource, string $permission): bool
+    {
+        $employee = Context::getContext()->employee;
+        if (!$employee || !(int) $employee->id_profile) {
+            return false;
+        }
+
+        $profileId = (int) $employee->id_profile;
+        $grantedActions = $this->getProfilePermissions($profileId, $resource);
+
+        return in_array($permission, $grantedActions, true);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getProfilePermissions(int $profileId, string $resource): array
+    {
+        $configuredPermissions = $this->getConfiguredPermissions();
+        if (isset($configuredPermissions[$profileId][$resource]) && is_array($configuredPermissions[$profileId][$resource])) {
+            return $configuredPermissions[$profileId][$resource];
+        }
+
+        return $this->buildFallbackPermissions($profileId, $resource);
+    }
+
+    /**
+     * @return array<int, array<string, array<int, string>>>
+     */
+    private function getConfiguredPermissions(): array
+    {
+        $raw = (string) Configuration::get(self::CONFIG_KEY);
+        if ($raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildFallbackPermissions(int $profileId, string $resource): array
+    {
+        if (!isset(self::RESOURCE_TAB_MAP[$resource])) {
+            return [];
+        }
+
+        $tabId = (int) Tab::getIdFromClassName(self::RESOURCE_TAB_MAP[$resource]);
+        if ($tabId <= 0) {
+            return [];
+        }
+
+        $profileAccess = Profile::getProfileAccess($profileId, $tabId);
+        if (!is_array($profileAccess)) {
+            return [];
+        }
+
+        $permissions = [];
+
+        if (!empty($profileAccess['view'])) {
+            $permissions[] = BlogPermission::READ;
+        }
+        if (!empty($profileAccess['add'])) {
+            $permissions[] = BlogPermission::CREATE;
+        }
+        if (!empty($profileAccess['edit'])) {
+            $permissions[] = BlogPermission::UPDATE;
+            $permissions[] = BlogPermission::PUBLISH;
+        }
+        if (!empty($profileAccess['delete'])) {
+            $permissions[] = BlogPermission::DELETE;
+        }
+
+        return $permissions;
+    }
+}

--- a/views/templates/admin/helpers/lists/list_action_delete_post.tpl
+++ b/views/templates/admin/helpers/lists/list_action_delete_post.tpl
@@ -16,6 +16,8 @@
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
 *}
 
-<a href="{$href|escape:'htmlall':'UTF-8'}"{if isset($confirm)} onclick="if (confirm('{$confirm|escape:'htmlall':'UTF-8'}')){ldelim}return true;{rdelim}else{ldelim}event.stopPropagation(); event.preventDefault();{rdelim};"{/if} title="{$action|escape:'htmlall':'UTF-8'}">
-	<i class="icon-trash"></i> {$action|escape:'htmlall':'UTF-8'}
-</a>
+<form method="post" action="{$href|escape:'htmlall':'UTF-8'}" style="display:inline;">
+	<button type="submit" class="btn btn-link p-0" title="{$action|escape:'htmlall':'UTF-8'}"{if isset($confirm)} onclick="return confirm('{$confirm|escape:'htmlall':'UTF-8'}');"{/if}>
+		<i class="icon-trash"></i> {$action|escape:'htmlall':'UTF-8'}
+	</button>
+</form>


### PR DESCRIPTION
### Motivation

- Introduce a business permission model (read/create/update/delete/publish) per BO resource to control employee access by profile and allow configuration overrides. 
- Replace brittle manual token checks used in legacy controllers with Symfony CSRF validation for POST/modify actions to improve security. 
- Add centralized audit logging for sensitive back-office actions (deletion, bulk publish, media import) to provide traceability. 

### Description

- Added a permission model and voter: `src/Security/BlogPermission.php`, `src/Security/BlogResourceVoter.php`, and a provider `src/Service/Security/BackOfficePermissionProvider.php` that maps `id_profile` permissions and falls back to `Profile::getProfileAccess`. 
- Enforced authorization in modern controllers (`src/Controller/Admin/*Controller.php`) via a new helper `denyBlogAccess` in `AbstractDomainController` and used `BlogPermission` constants at list/form and mutate endpoints. 
- Added CSRF handling and sensitive action logging to controllers: `src/Controller/Admin/PostController.php` now validates CSRF tokens for `create/update/delete` and logs deletions via `src/Service/Audit/SensitiveActionLogger.php`. 
- Updated legacy admin controllers and templates to use CSRF + audit: added centralized CSRF helpers and `logSensitiveAction` in `controllers/admin/EverPsBlogAdminController.php`, switched the post delete action to a `POST` form (`views/templates/admin/helpers/lists/list_action_delete_post.tpl`), and added audit logs for bulk delete/publish and media imports; wired services in `config/services.yml`. 

### Testing

- Ran the module-wide syntax check via `tools/php_syntax_check.sh` and it completed with no syntax errors. 
- Ran targeted PHP lint checks with `php -l` for new/updated files and all returned `No syntax errors detected`. 
- No automated functional tests were added; manual runtime verification of CSRF/voter behavior is recommended in an environment with the PrestaShop Symfony container available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df5d12bc10832298d0526c44583c2f)