### PR TITLE
Migrate blog post command handlers to Doctrine persistence with PostRead/PostWrite repositories

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -22,14 +22,31 @@ services:
     class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\CreatePostHandler
     arguments:
       - '@prestashop.module.everpsblog.blog.post_rules_applier'
+      - '@prestashop.module.everpsblog.blog.repository.post_write'
 
   prestashop.module.everpsblog.blog.update_post_handler:
     class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\UpdatePostHandler
     arguments:
+      - '@doctrine.orm.entity_manager'
       - '@prestashop.module.everpsblog.blog.post_rules_applier'
+      - '@prestashop.module.everpsblog.blog.repository.post_write'
 
   prestashop.module.everpsblog.blog.delete_post_handler:
     class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\DeletePostHandler
+    arguments:
+      - '@doctrine.orm.entity_manager'
+      - '@prestashop.module.everpsblog.blog.repository.post_write'
+
+
+  prestashop.module.everpsblog.blog.repository.post_read:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\PostReadRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
+
+  prestashop.module.everpsblog.blog.repository.post_write:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\PostWriteRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
 
   prestashop.module.everpsblog.blog.command_bus:
     class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\InMemoryCommandBus

--- a/src/Core/Domain/Blog/CommandHandler/CreatePostHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/CreatePostHandler.php
@@ -2,25 +2,32 @@
 
 namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
 
-use EverPsBlogPost;
 use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreatePostCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\PostWriteRepository;
+use PrestaShop\Module\Everpsblog\Entity\Post;
 
 class CreatePostHandler
 {
     /** @var PostRulesApplier */
     private $rulesApplier;
+    /** @var PostWriteRepository */
+    private $postWriteRepository;
 
-    public function __construct(PostRulesApplier $rulesApplier)
-    {
+    public function __construct(
+        PostRulesApplier $rulesApplier,
+        PostWriteRepository $postWriteRepository
+    ) {
         $this->rulesApplier = $rulesApplier;
+        $this->postWriteRepository = $postWriteRepository;
     }
 
     public function __invoke(CreatePostCommand $command): int
     {
-        $post = new EverPsBlogPost();
-        $this->rulesApplier->apply($post, $command->getData()->toArray());
-        $post->save();
+        $post = new Post();
+        $relations = $this->rulesApplier->apply($post, $command->getData()->toArray());
 
-        return (int) $post->id;
+        $this->postWriteRepository->save($post, $relations);
+
+        return (int) $post->getId();
     }
 }

--- a/src/Core/Domain/Blog/CommandHandler/DeletePostHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/DeletePostHandler.php
@@ -2,14 +2,33 @@
 
 namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
 
-use EverPsBlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
 use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeletePostCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\PostWriteRepository;
+use PrestaShop\Module\Everpsblog\Entity\Post;
 
 class DeletePostHandler
 {
+    /** @var EntityManagerInterface */
+    private $entityManager;
+    /** @var PostWriteRepository */
+    private $postWriteRepository;
+
+    public function __construct(EntityManagerInterface $entityManager, PostWriteRepository $postWriteRepository)
+    {
+        $this->entityManager = $entityManager;
+        $this->postWriteRepository = $postWriteRepository;
+    }
+
     public function __invoke(DeletePostCommand $command): void
     {
-        $post = new EverPsBlogPost($command->getPostId());
-        $post->delete();
+        /** @var Post|null $post */
+        $post = $this->entityManager->getRepository(Post::class)->find($command->getPostId());
+        if (null === $post) {
+            throw new InvalidArgumentException(sprintf('Post with id %d not found.', $command->getPostId()));
+        }
+
+        $this->postWriteRepository->delete($post);
     }
 }

--- a/src/Core/Domain/Blog/CommandHandler/PostRulesApplier.php
+++ b/src/Core/Domain/Blog/CommandHandler/PostRulesApplier.php
@@ -2,43 +2,50 @@
 
 namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
 
-use EverPsBlogPost;
+use DateTimeImmutable;
 use InvalidArgumentException;
+use PrestaShop\Module\Everpsblog\Entity\Post;
+use PrestaShop\Module\Everpsblog\Entity\PostCategory;
+use PrestaShop\Module\Everpsblog\Entity\PostLang;
+use PrestaShop\Module\Everpsblog\Entity\PostProduct;
+use PrestaShop\Module\Everpsblog\Entity\PostShop;
+use PrestaShop\Module\Everpsblog\Entity\PostTag;
 
 class PostRulesApplier
 {
     /**
      * @param array<string, mixed> $payload
+     *
+     * @return array<string, array<int, object>>
      */
-    public function apply(EverPsBlogPost $post, array $payload): void
+    public function apply(Post $post, array $payload): array
     {
-        $post->id_shop = (int) $payload['shop_id'];
-        $post->id_author = (int) $payload['author_id'];
-        $post->date_add = (string) $payload['date_add'];
-        $post->date_upd = date('Y-m-d H:i:s');
-        $post->indexable = (int) $payload['indexable'];
-        $post->follow = (int) $payload['follow'];
-        $post->sitemap = (int) $payload['sitemap'];
-        $post->starred = (int) $payload['starred'];
+        $post->setAuthorId((int) $payload['author_id']);
+        $post->setDefaultCategoryId($this->resolveDefaultCategory($payload));
+        $post->setCreatedAt(new DateTimeImmutable((string) $payload['date_add']));
+        $post->setUpdatedAt(new DateTimeImmutable('now'));
+        $post->setIndexable((bool) $payload['indexable']);
+        $post->setFollow((bool) $payload['follow']);
+        $post->setSitemap((bool) $payload['sitemap']);
+        $post->setStarred((int) $payload['starred']);
+        $post->setAllowedGroups($this->encodeArray($payload['allowed_groups']));
+        $post->setStatus($this->resolveStatus($payload));
+        $post->setPassword($this->resolvePassword($payload, $post->getStatus()));
 
-        $post->id_default_category = $this->resolveDefaultCategory($payload);
-        $post->post_categories = json_encode($this->resolveCategoryAssociations($payload, (int) $post->id_default_category));
-        $post->allowed_groups = json_encode($payload['allowed_groups']);
-        $post->post_tags = json_encode($payload['post_tags']);
-        $post->post_products = json_encode($payload['post_products']);
-        $post->post_status = $this->resolveStatus($payload);
-        $post->psswd = $this->resolvePassword($payload, $post->post_status);
+        $postId = $post->getId();
 
-        foreach ($payload['translations'] as $idLang => $translation) {
-            $post->title[$idLang] = $translation['title'];
-            $post->content[$idLang] = $translation['content'];
-            $post->excerpt[$idLang] = $translation['excerpt'];
-            $post->meta_title[$idLang] = $translation['meta_title'];
-            $post->meta_description[$idLang] = $translation['meta_description'];
-            $post->link_rewrite[$idLang] = $translation['link_rewrite'];
-        }
+        return [
+            'langs' => $this->buildPostLangs($postId, $payload),
+            'shops' => [PostShop::create($postId, (int) $payload['shop_id'])],
+            'categories' => $this->buildPostCategories($postId, $payload, $post->getDefaultCategoryId()),
+            'tags' => $this->buildPostTags($postId, $payload),
+            'products' => $this->buildPostProducts($postId, $payload),
+        ];
     }
 
+    /**
+     * @param array<string, mixed> $payload
+     */
     private function resolveDefaultCategory(array $payload): int
     {
         $defaultCategoryId = (int) $payload['default_category_id'];
@@ -54,16 +61,9 @@ class PostRulesApplier
         return $defaultCategoryId;
     }
 
-    private function resolveCategoryAssociations(array $payload, int $defaultCategoryId): array
-    {
-        $categories = $payload['post_categories'];
-        if (!in_array($defaultCategoryId, $categories)) {
-            $categories[] = $defaultCategoryId;
-        }
-
-        return array_values(array_unique(array_map('intval', $categories)));
-    }
-
+    /**
+     * @param array<string, mixed> $payload
+     */
     private function resolveStatus(array $payload): string
     {
         if ((string) $payload['date_add'] > date('Y-m-d H:i:s')) {
@@ -73,6 +73,9 @@ class PostRulesApplier
         return (string) $payload['post_status'];
     }
 
+    /**
+     * @param array<string, mixed> $payload
+     */
     private function resolvePassword(array $payload, string $status): ?string
     {
         if ($status !== 'protected' || empty($payload['password'])) {
@@ -80,5 +83,89 @@ class PostRulesApplier
         }
 
         return md5(_COOKIE_KEY_ . $payload['password']);
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encodeArray($value): ?string
+    {
+        if (!is_array($value) || empty($value)) {
+            return null;
+        }
+
+        return json_encode(array_values($value));
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return PostLang[]
+     */
+    private function buildPostLangs(?int $postId, array $payload): array
+    {
+        $langs = [];
+
+        foreach ($payload['translations'] as $langId => $translation) {
+            $langs[] = PostLang::create(
+                $postId,
+                (int) $langId,
+                (string) $translation['title'],
+                (string) $translation['content'],
+                (string) $translation['excerpt'],
+                (string) $translation['meta_title'],
+                (string) $translation['meta_description'],
+                (string) $translation['link_rewrite']
+            );
+        }
+
+        return $langs;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return PostCategory[]
+     */
+    private function buildPostCategories(?int $postId, array $payload, int $defaultCategoryId): array
+    {
+        $categories = $payload['post_categories'];
+        if (!in_array($defaultCategoryId, $categories)) {
+            $categories[] = $defaultCategoryId;
+        }
+
+        $categories = array_values(array_unique(array_map('intval', $categories)));
+
+        return array_map(static function ($categoryId) use ($postId) {
+            return PostCategory::create($postId, (int) $categoryId);
+        }, $categories);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return PostTag[]
+     */
+    private function buildPostTags(?int $postId, array $payload): array
+    {
+        $tags = array_values(array_unique(array_map('intval', $payload['post_tags'])));
+
+        return array_map(static function ($tagId) use ($postId) {
+            return PostTag::create($postId, (int) $tagId);
+        }, $tags);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return PostProduct[]
+     */
+    private function buildPostProducts(?int $postId, array $payload): array
+    {
+        $products = array_values(array_unique(array_map('intval', $payload['post_products'])));
+
+        return array_map(static function ($productId) use ($postId) {
+            return PostProduct::create($postId, (int) $productId);
+        }, $products);
     }
 }

--- a/src/Core/Domain/Blog/CommandHandler/UpdatePostHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/UpdatePostHandler.php
@@ -2,25 +2,42 @@
 
 namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
 
-use EverPsBlogPost;
+use Doctrine\ORM\EntityManagerInterface;
+use InvalidArgumentException;
 use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdatePostCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\PostWriteRepository;
+use PrestaShop\Module\Everpsblog\Entity\Post;
 
 class UpdatePostHandler
 {
+    /** @var EntityManagerInterface */
+    private $entityManager;
     /** @var PostRulesApplier */
     private $rulesApplier;
+    /** @var PostWriteRepository */
+    private $postWriteRepository;
 
-    public function __construct(PostRulesApplier $rulesApplier)
-    {
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        PostRulesApplier $rulesApplier,
+        PostWriteRepository $postWriteRepository
+    ) {
+        $this->entityManager = $entityManager;
         $this->rulesApplier = $rulesApplier;
+        $this->postWriteRepository = $postWriteRepository;
     }
 
     public function __invoke(UpdatePostCommand $command): int
     {
-        $post = new EverPsBlogPost($command->getPostId());
-        $this->rulesApplier->apply($post, $command->getData()->toArray());
-        $post->save();
+        /** @var Post|null $post */
+        $post = $this->entityManager->getRepository(Post::class)->find($command->getPostId());
+        if (null === $post) {
+            throw new InvalidArgumentException(sprintf('Post with id %d not found.', $command->getPostId()));
+        }
 
-        return (int) $post->id;
+        $relations = $this->rulesApplier->apply($post, $command->getData()->toArray());
+        $this->postWriteRepository->save($post, $relations);
+
+        return (int) $post->getId();
     }
 }

--- a/src/Core/Domain/Blog/Repository/PostReadRepository.php
+++ b/src/Core/Domain/Blog/Repository/PostReadRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\Module\Everpsblog\Entity\Post;
+
+class PostReadRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function getById(int $postId): ?Post
+    {
+        /** @var Post|null $post */
+        $post = $this->entityManager->getRepository(Post::class)->find($postId);
+
+        return $post;
+    }
+}

--- a/src/Core/Domain/Blog/Repository/PostWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/PostWriteRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\Module\Everpsblog\Entity\Post;
+
+class PostWriteRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * @param array<string, array<int, object>> $relations
+     */
+    public function save(Post $post, array $relations): void
+    {
+        $this->entityManager->wrapInTransaction(function () use ($post, $relations) {
+            $this->entityManager->persist($post);
+            $this->entityManager->flush();
+
+            $postId = (int) $post->getId();
+            $this->clearRelations($postId);
+            $this->persistRelations($postId, $relations);
+
+            $this->entityManager->flush();
+        });
+    }
+
+    public function delete(Post $post): void
+    {
+        $this->entityManager->wrapInTransaction(function () use ($post) {
+            $postId = (int) $post->getId();
+            $this->clearRelations($postId);
+            $this->entityManager->remove($post);
+            $this->entityManager->flush();
+        });
+    }
+
+    private function clearRelations(int $postId): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_post_lang', ['id_ever_post' => $postId]);
+        $connection->delete('ever_blog_post_shop', ['id_ever_post' => $postId]);
+        $connection->delete('ever_blog_post_category', ['id_ever_post' => $postId]);
+        $connection->delete('ever_blog_post_tag', ['id_ever_post' => $postId]);
+        $connection->delete('ever_blog_post_product', ['id_ever_post' => $postId]);
+    }
+
+    /**
+     * @param array<string, array<int, object>> $relations
+     */
+    private function persistRelations(int $postId, array $relations): void
+    {
+        foreach ($relations as $entities) {
+            foreach ($entities as $entity) {
+                if (method_exists($entity, 'setPostId')) {
+                    $entity->setPostId($postId);
+                }
+
+                $this->entityManager->persist($entity);
+            }
+        }
+    }
+}

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -2,6 +2,7 @@
 
 namespace PrestaShop\Module\Everpsblog\Entity;
 
+use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -60,6 +61,30 @@ class Post
         return $this->id;
     }
 
+    public function getAuthorId()
+    {
+        return $this->authorId;
+    }
+
+    public function setAuthorId($authorId)
+    {
+        $this->authorId = $authorId;
+
+        return $this;
+    }
+
+    public function getDefaultCategoryId()
+    {
+        return $this->defaultCategoryId;
+    }
+
+    public function setDefaultCategoryId($defaultCategoryId)
+    {
+        $this->defaultCategoryId = $defaultCategoryId;
+
+        return $this;
+    }
+
     public function getStatus()
     {
         return $this->status;
@@ -68,6 +93,62 @@ class Post
     public function setStatus($status)
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function setIndexable($indexable)
+    {
+        $this->indexable = $indexable;
+
+        return $this;
+    }
+
+    public function setFollow($follow)
+    {
+        $this->follow = $follow;
+
+        return $this;
+    }
+
+    public function setSitemap($sitemap)
+    {
+        $this->sitemap = $sitemap;
+
+        return $this;
+    }
+
+    public function setPassword($password)
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
+    public function setStarred($starred)
+    {
+        $this->starred = $starred;
+
+        return $this;
+    }
+
+    public function setAllowedGroups($allowedGroups)
+    {
+        $this->allowedGroups = $allowedGroups;
+
+        return $this;
+    }
+
+    public function setCreatedAt(DateTimeInterface $createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function setUpdatedAt(DateTimeInterface $updatedAt)
+    {
+        $this->updatedAt = $updatedAt;
 
         return $this;
     }

--- a/src/Entity/PostCategory.php
+++ b/src/Entity/PostCategory.php
@@ -12,4 +12,25 @@ class PostCategory
 
     /** @ORM\Id @ORM\Column(name="id_ever_post_category", type="integer") */
     private $categoryId;
+
+    public static function create(?int $postId, int $categoryId): self
+    {
+        $postCategory = new self();
+        $postCategory->postId = $postId;
+        $postCategory->categoryId = $categoryId;
+
+        return $postCategory;
+    }
+
+    public function setPostId(int $postId): self
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
 }

--- a/src/Entity/PostLang.php
+++ b/src/Entity/PostLang.php
@@ -33,4 +33,39 @@ class PostLang
 
     /** @ORM\Column(name="excerpt", type="string", length=255, nullable=true) */
     private $excerpt;
+
+    public static function create(
+        ?int $postId,
+        int $langId,
+        string $title,
+        string $content,
+        ?string $excerpt,
+        ?string $metaTitle,
+        ?string $metaDescription,
+        ?string $linkRewrite
+    ): self {
+        $postLang = new self();
+        $postLang->postId = $postId;
+        $postLang->langId = $langId;
+        $postLang->title = $title;
+        $postLang->content = $content;
+        $postLang->excerpt = $excerpt;
+        $postLang->metaTitle = $metaTitle;
+        $postLang->metaDescription = $metaDescription;
+        $postLang->linkRewrite = $linkRewrite;
+
+        return $postLang;
+    }
+
+    public function setPostId(int $postId): self
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
 }

--- a/src/Entity/PostProduct.php
+++ b/src/Entity/PostProduct.php
@@ -12,4 +12,25 @@ class PostProduct
 
     /** @ORM\Id @ORM\Column(name="id_ever_post_product", type="integer") */
     private $productId;
+
+    public static function create(?int $postId, int $productId): self
+    {
+        $postProduct = new self();
+        $postProduct->postId = $postId;
+        $postProduct->productId = $productId;
+
+        return $postProduct;
+    }
+
+    public function setPostId(int $postId): self
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
 }

--- a/src/Entity/PostShop.php
+++ b/src/Entity/PostShop.php
@@ -15,4 +15,25 @@ class PostShop
 
     /** @ORM\Id @ORM\Column(name="id_shop", type="integer") */
     private $shopId;
+
+    public static function create(?int $postId, int $shopId): self
+    {
+        $postShop = new self();
+        $postShop->postId = $postId;
+        $postShop->shopId = $shopId;
+
+        return $postShop;
+    }
+
+    public function setPostId(int $postId): self
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
 }

--- a/src/Entity/PostTag.php
+++ b/src/Entity/PostTag.php
@@ -12,4 +12,25 @@ class PostTag
 
     /** @ORM\Id @ORM\Column(name="id_ever_post_tag", type="integer") */
     private $tagId;
+
+    public static function create(?int $postId, int $tagId): self
+    {
+        $postTag = new self();
+        $postTag->postId = $postId;
+        $postTag->tagId = $tagId;
+
+        return $postTag;
+    }
+
+    public function setPostId(int $postId): self
+    {
+        $this->postId = $postId;
+
+        return $this;
+    }
+
+    public function getPostId(): ?int
+    {
+        return $this->postId;
+    }
 }


### PR DESCRIPTION
### Motivation
- Replace legacy `EverPsBlogPost` model usage in command handlers with Doctrine entities and repositories to modernize persistence and centralize multi-table operations.
- Move translation/shop/category/tag/product association logic out of legacy model into a rules applier that builds relation entities for Doctrine.
- Encapsulate multi-table transactional persistence and deletion behind dedicated repositories to keep handlers thin and controllers unchanged.

### Description
- Reworked `CreatePostHandler`, `UpdatePostHandler`, and `DeletePostHandler` to operate on the Doctrine entity `PrestaShop\Module\Everpsblog\Entity\Post` and to delegate persistence to `PostWriteRepository` while using `EntityManagerInterface` where needed.
- Refactored `PostRulesApplier` to apply payloads on the `Post` entity and return relation entity arrays (`PostLang`, `PostShop`, `PostCategory`, `PostTag`, `PostProduct`) for persistence instead of mutating a legacy object.
- Added domain repositories `PostReadRepository` and `PostWriteRepository` where `PostWriteRepository` handles transactional save/delete flows, clears previous relations in DB, and persists supplied relation entities.
- Updated related entities to include factory `create()` helpers and `setPostId()`/setters required for the write flow, and updated DI wiring in `config/services.yml` to register the new repositories and handler dependencies while keeping the `CreatePostCommand`, `UpdatePostCommand`, and `DeletePostCommand` contracts unchanged.

### Testing
- Ran PHP syntax checks for modified files with `php -l` across the updated handlers, repositories, and entity files, and all checks succeeded.
- Searched for remaining legacy references with `rg -n "EverPsBlogPost" src/Core/Domain/Blog` and confirmed there are no remaining references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1de0cddf883229fd2dc1e2845eb83)