### PR TITLE
Add install-time fallback for missing blog install service

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -199,7 +199,12 @@ class EverPsBlog extends Module
 
     private function getBlogInstallService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_install');
+        try {
+            return $this->getModuleService('prestashop.module.everpsblog.service.blog_install');
+        } catch (\Throwable $exception) {
+            // During module install, module Symfony services can be unavailable.
+            return new \PrestaShop\Module\Everpsblog\Service\BlogInstallService();
+        }
     }
 
     private function getBlogTaxonomyService()


### PR DESCRIPTION
### Motivation
- Prevent module install crashes when the Symfony service `prestashop.module.everpsblog.service.blog_install` is not yet registered and causes a "non-existent service" error.

### Description
- Wrap the call to `getModuleService('prestashop.module.everpsblog.service.blog_install')` in a `try/catch` inside `EverPsBlog::getBlogInstallService()` and return a direct instance of `\PrestaShop\Module\Everpsblog\Service\BlogInstallService` on failure.

### Testing
- Ran `php -l everpsblog.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2106be7888322850e227325eef003)