### PR TITLE
Fix BO admin tabs routing and add Symfony dashboard for Ever Blog (6.0.5)

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -1,9 +1,18 @@
+everpsblog_admin_dashboard:
+  path: /everpsblog
+  methods: [GET]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\ConfigurationController::indexAction'
+    _legacy_controller: AdminEverPsBlog
+    _legacy_link: AdminEverPsBlog
+
 everpsblog_admin_post:
   path: /everpsblog/post
   methods: [GET]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\PostController::indexAction'
     _legacy_controller: AdminEverPsBlogPost
+    _legacy_link: AdminEverPsBlogPost
 
 everpsblog_admin_post_form:
   path: /everpsblog/post/new
@@ -11,6 +20,7 @@ everpsblog_admin_post_form:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\PostController::formAction'
     _legacy_controller: AdminEverPsBlogPost
+    _legacy_link: AdminEverPsBlogPost:add
 
 everpsblog_admin_post_edit:
   path: /everpsblog/post/{postId}/edit
@@ -18,6 +28,7 @@ everpsblog_admin_post_edit:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\PostController::formAction'
     _legacy_controller: AdminEverPsBlogPost
+    _legacy_link: AdminEverPsBlogPost:edit
   requirements:
     postId: '\d+'
 
@@ -52,6 +63,7 @@ everpsblog_admin_category:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::indexAction'
     _legacy_controller: AdminEverPsBlogCategory
+    _legacy_link: AdminEverPsBlogCategory
 
 everpsblog_admin_category_form:
   path: /everpsblog/category/new
@@ -59,6 +71,7 @@ everpsblog_admin_category_form:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::formAction'
     _legacy_controller: AdminEverPsBlogCategory
+    _legacy_link: AdminEverPsBlogCategory:add
 
 everpsblog_admin_category_edit:
   path: /everpsblog/category/{categoryId}/edit
@@ -66,6 +79,7 @@ everpsblog_admin_category_edit:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::formAction'
     _legacy_controller: AdminEverPsBlogCategory
+    _legacy_link: AdminEverPsBlogCategory:edit
   requirements:
     categoryId: '\d+'
 
@@ -75,6 +89,7 @@ everpsblog_admin_tag:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::indexAction'
     _legacy_controller: AdminEverPsBlogTag
+    _legacy_link: AdminEverPsBlogTag
 
 everpsblog_admin_tag_form:
   path: /everpsblog/tag/new
@@ -82,6 +97,7 @@ everpsblog_admin_tag_form:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::formAction'
     _legacy_controller: AdminEverPsBlogTag
+    _legacy_link: AdminEverPsBlogTag:add
 
 everpsblog_admin_tag_edit:
   path: /everpsblog/tag/{tagId}/edit
@@ -89,6 +105,7 @@ everpsblog_admin_tag_edit:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::formAction'
     _legacy_controller: AdminEverPsBlogTag
+    _legacy_link: AdminEverPsBlogTag:edit
   requirements:
     tagId: '\d+'
 
@@ -98,6 +115,7 @@ everpsblog_admin_author:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::indexAction'
     _legacy_controller: AdminEverPsBlogAuthor
+    _legacy_link: AdminEverPsBlogAuthor
 
 everpsblog_admin_author_form:
   path: /everpsblog/author/new
@@ -105,6 +123,7 @@ everpsblog_admin_author_form:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::formAction'
     _legacy_controller: AdminEverPsBlogAuthor
+    _legacy_link: AdminEverPsBlogAuthor:add
 
 everpsblog_admin_author_edit:
   path: /everpsblog/author/{authorId}/edit
@@ -112,6 +131,7 @@ everpsblog_admin_author_edit:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::formAction'
     _legacy_controller: AdminEverPsBlogAuthor
+    _legacy_link: AdminEverPsBlogAuthor:edit
   requirements:
     authorId: '\d+'
 
@@ -121,6 +141,7 @@ everpsblog_admin_comment:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::indexAction'
     _legacy_controller: AdminEverPsBlogComment
+    _legacy_link: AdminEverPsBlogComment
 
 everpsblog_admin_comment_form:
   path: /everpsblog/comment/new
@@ -128,6 +149,7 @@ everpsblog_admin_comment_form:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::formAction'
     _legacy_controller: AdminEverPsBlogComment
+    _legacy_link: AdminEverPsBlogComment:add
 
 everpsblog_admin_comment_edit:
   path: /everpsblog/comment/{commentId}/edit
@@ -135,5 +157,6 @@ everpsblog_admin_comment_edit:
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::formAction'
     _legacy_controller: AdminEverPsBlogComment
+    _legacy_link: AdminEverPsBlogComment:edit
   requirements:
     commentId: '\d+'

--- a/config/services.yml
+++ b/config/services.yml
@@ -144,3 +144,24 @@ services:
     factory: ['@doctrine.orm.entity_manager', getRepository]
     arguments:
       - 'PrestaShop\Module\Everpsblog\Entity\Image'
+
+  PrestaShop\Module\Everpsblog\Form\DataProvider\:
+    resource: '../src/Form/DataProvider/*'
+
+  PrestaShop\Module\Everpsblog\Grid\Definition\:
+    resource: '../src/Grid/Definition/*'
+
+  PrestaShop\Module\Everpsblog\Grid\Data\:
+    resource: '../src/Grid/Data/*'
+
+  PrestaShop\Module\Everpsblog\Service\Audit\:
+    resource: '../src/Service/Audit/*'
+
+  PrestaShop\Module\Everpsblog\Controller\Admin\:
+    resource: '../src/Controller/Admin/*'
+    public: true
+    tags: ['controller.service_arguments']
+
+  PrestaShop\Module\Everpsblog\Form\Type\Admin\:
+    resource: '../src/Form/Type/Admin/*'
+    tags: ['form.type']

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -36,7 +36,7 @@ class EverPsBlog extends Module
     {
         $this->name = 'everpsblog';
         $this->tab = 'front_office_features';
-        $this->version = '6.0.4';
+        $this->version = '6.0.5';
         $this->author = 'Team Ever';
         $this->need_instance = 0;
         $this->bootstrap = true;
@@ -85,27 +85,27 @@ class EverPsBlog extends Module
                 $this->l('Blog')
             )
             && $this->installModuleTab(
-                'everpsblog_admin_post',
+                'AdminEverPsBlogPost',
                 'AdminEverPsBlog',
                 $this->l('Posts')
             )
             && $this->installModuleTab(
-                'everpsblog_admin_category',
+                'AdminEverPsBlogCategory',
                 'AdminEverPsBlog',
                 $this->l('Categories')
             )
             && $this->installModuleTab(
-                'everpsblog_admin_tag',
+                'AdminEverPsBlogTag',
                 'AdminEverPsBlog',
                 $this->l('Tags')
             )
             && $this->installModuleTab(
-                'everpsblog_admin_comment',
+                'AdminEverPsBlogComment',
                 'AdminEverPsBlog',
                 $this->l('Comments')
             )
             && $this->installModuleTab(
-                'everpsblog_admin_author',
+                'AdminEverPsBlogAuthor',
                 'AdminEverPsBlog',
                 $this->l('Authors')
             )
@@ -158,11 +158,11 @@ class EverPsBlog extends Module
         Configuration::deleteByName('EVERBLOG_SHOW_POST_TAGS');
         return parent::uninstall()
             && $this->uninstallModuleTab('AdminEverPsBlog')
-            && $this->uninstallModuleTab('everpsblog_admin_post')
-            && $this->uninstallModuleTab('everpsblog_admin_category')
-            && $this->uninstallModuleTab('everpsblog_admin_tag')
-            && $this->uninstallModuleTab('everpsblog_admin_comment')
-            && $this->uninstallModuleTab('everpsblog_admin_author');
+            && $this->uninstallModuleTab('AdminEverPsBlogPost')
+            && $this->uninstallModuleTab('AdminEverPsBlogCategory')
+            && $this->uninstallModuleTab('AdminEverPsBlogTag')
+            && $this->uninstallModuleTab('AdminEverPsBlogComment')
+            && $this->uninstallModuleTab('AdminEverPsBlogAuthor');
     }
 
     private function installModuleTab($tabClass, $parent, $tabName)
@@ -689,31 +689,31 @@ class EverPsBlog extends Module
         );
         $quickLinks = [
             [
-                'href' => $this->context->link->getAdminLink('everpsblog_admin_post'),
+                'href' => $this->context->link->getAdminLink('AdminEverPsBlogPost'),
                 'label' => $this->l('Manage posts'),
                 'description' => $this->l('Create, edit or schedule blog articles'),
                 'icon' => 'icon-pencil',
             ],
             [
-                'href' => $this->context->link->getAdminLink('everpsblog_admin_category'),
+                'href' => $this->context->link->getAdminLink('AdminEverPsBlogCategory'),
                 'label' => $this->l('Organise categories'),
                 'description' => $this->l('Structure your content and improve navigation'),
                 'icon' => 'icon-folder-open',
             ],
             [
-                'href' => $this->context->link->getAdminLink('everpsblog_admin_tag'),
+                'href' => $this->context->link->getAdminLink('AdminEverPsBlogTag'),
                 'label' => $this->l('Curate tags'),
                 'description' => $this->l('Highlight related topics for your readers'),
                 'icon' => 'icon-tags',
             ],
             [
-                'href' => $this->context->link->getAdminLink('everpsblog_admin_author'),
+                'href' => $this->context->link->getAdminLink('AdminEverPsBlogAuthor'),
                 'label' => $this->l('Manage authors'),
                 'description' => $this->l('Keep contributor profiles up to date'),
                 'icon' => 'icon-user',
             ],
             [
-                'href' => $this->context->link->getAdminLink('everpsblog_admin_comment'),
+                'href' => $this->context->link->getAdminLink('AdminEverPsBlogComment'),
                 'label' => $this->l('Moderate comments'),
                 'description' => $this->l('Review community feedback in one place'),
                 'icon' => 'icon-comments',
@@ -2373,16 +2373,12 @@ class EverPsBlog extends Module
         }
         if ((bool) Configuration::get('EVERBLOG_TINYMCE') === true) {
             $blogAdminControllers = [
+                'AdminEverPsBlog',
                 'AdminEverPsBlogPost',
                 'AdminEverPsBlogTag',
                 'AdminEverPsBlogAuthor',
                 'AdminEverPsBlogCategory',
                 'AdminEverPsBlogComment',
-                'everpsblog_admin_post',
-                'everpsblog_admin_tag',
-                'everpsblog_admin_author',
-                'everpsblog_admin_category',
-                'everpsblog_admin_comment',
             ];
             if (in_array(Tools::getValue('controller'), $blogAdminControllers)
                 || Tools::getValue('configure') == $this->name

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Controller\Admin;
+
+use PrestaShop\Module\Everpsblog\Security\BlogPermission;
+use Symfony\Component\HttpFoundation\Response;
+
+class ConfigurationController extends AbstractDomainController
+{
+    public function indexAction(): Response
+    {
+        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_POST);
+
+        return $this->render('@Modules/everpsblog/views/templates/admin/modern/configuration.html.twig', [
+            'postUrl' => $this->generateUrl('everpsblog_admin_post'),
+            'categoryUrl' => $this->generateUrl('everpsblog_admin_category'),
+            'tagUrl' => $this->generateUrl('everpsblog_admin_tag'),
+            'authorUrl' => $this->generateUrl('everpsblog_admin_author'),
+            'commentUrl' => $this->generateUrl('everpsblog_admin_comment'),
+            'legacyConfigureUrl' => $this->generateUrl('admin_module_manage_action', [
+                'module_name' => 'everpsblog',
+                'action' => 'configure',
+            ]),
+        ]);
+    }
+}

--- a/upgrade/upgrade-6.0.5.php
+++ b/upgrade/upgrade-6.0.5.php
@@ -1,0 +1,27 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_6_0_5()
+{
+    $result = true;
+
+    $map = [
+        'everpsblog_admin_post' => 'AdminEverPsBlogPost',
+        'everpsblog_admin_category' => 'AdminEverPsBlogCategory',
+        'everpsblog_admin_tag' => 'AdminEverPsBlogTag',
+        'everpsblog_admin_comment' => 'AdminEverPsBlogComment',
+        'everpsblog_admin_author' => 'AdminEverPsBlogAuthor',
+    ];
+
+    foreach ($map as $legacyClass => $modernClass) {
+        $result &= (bool) Db::getInstance()->update(
+            'tab',
+            ['class_name' => pSQL($modernClass)],
+            'class_name = "' . pSQL($legacyClass) . '"'
+        );
+    }
+
+    return (bool) $result;
+}

--- a/views/templates/admin/modern/configuration.html.twig
+++ b/views/templates/admin/modern/configuration.html.twig
@@ -1,0 +1,25 @@
+{% extends '@PrestaShop/Admin/layout.html.twig' %}
+
+{% block content %}
+  <div class="card mb-3">
+    <h3 class="card-header">Ever Blog</h3>
+    <div class="card-body">
+      <p class="mb-3">Le back-office Ever Blog utilise désormais des contrôleurs Symfony.</p>
+      <div class="btn-group" role="group" aria-label="Ever Blog links">
+        <a class="btn btn-primary" href="{{ postUrl }}">Articles</a>
+        <a class="btn btn-outline-primary" href="{{ categoryUrl }}">Catégories</a>
+        <a class="btn btn-outline-primary" href="{{ tagUrl }}">Tags</a>
+        <a class="btn btn-outline-primary" href="{{ authorUrl }}">Auteurs</a>
+        <a class="btn btn-outline-primary" href="{{ commentUrl }}">Commentaires</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h3 class="card-header">Paramètres</h3>
+    <div class="card-body">
+      <p>Le formulaire historique reste disponible pendant la transition.</p>
+      <a class="btn btn-outline-secondary" href="{{ legacyConfigureUrl }}">Configurer le module</a>
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
### Motivation
- The Back Office menu opened a missing legacy controller and `getAdminLink()` pointed to legacy route-like identifiers instead of the legacy controller class names, making admin controllers unreachable. 
- The module configuration remained tied to the legacy UI while the BO screens were migrated to Symfony, so a Symfony dashboard was needed to surface the new controllers and provide a safe path to the historical configuration.

### Description
- Bumped module version to `6.0.5` and replaced route-like tab identifiers with legacy controller class names in the install/uninstall flow by using `AdminEverPsBlogPost`, `AdminEverPsBlogCategory`, `AdminEverPsBlogTag`, `AdminEverPsBlogComment` and `AdminEverPsBlogAuthor` instead of `everpsblog_admin_*` in `everpsblog.php` and updated `getAdminLink()` calls accordingly. 
- Added a dashboard Symfony route `everpsblog_admin_dashboard` and included `_legacy_link` metadata to admin routes in `config/routes.yml` for improved backward compatibility with legacy link generation. 
- Introduced `ConfigurationController` (Symfony) and a modern Twig template `views/templates/admin/modern/configuration.html.twig` to render a Symfony-based module dashboard linking to Posts/Categories/Tags/Authors/Comments and to the legacy configure form. 
- Registered admin controllers, form data providers, grid definitions/data providers, audit services and admin form types in `config/services.yml` so Symfony can autowire and instantiate controllers used in BO. 
- Adjusted `hookActionAdminControllerSetMedia` controllers list to include `AdminEverPsBlog` and removed remaining `everpsblog_admin_*` names. 
- Added `upgrade/upgrade-6.0.5.php` to migrate existing tab entries in the `tab` table from old `everpsblog_admin_*` names to the expected `AdminEverPsBlog*` classes for existing installations.

### Testing
- Ran PHP lint checks with `php -l everpsblog.php`, `php -l src/Controller/Admin/ConfigurationController.php` and `php -l upgrade/upgrade-6.0.5.php`, which all reported no syntax errors. 
- Attempted to validate YAML with `php -r "yaml_parse_file('config/routes.yml')"` and `php -r "yaml_parse_file('config/services.yml')"`, but the CLI `yaml` extension is not available in this environment so YAML parsing could not be completed here. 
- No unit/integration test suite was executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21ac8cb688322b549fe8cb055d3cd)