### PR TITLE
Add Symfony service alias for ContextStateService to fix autowiring

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -91,6 +91,9 @@ services:
   prestashop.module.everpsblog.service.context_state:
     class: PrestaShop\Module\Everpsblog\Service\ContextStateService
 
+  PrestaShop\Module\Everpsblog\Service\ContextStateService:
+    alias: prestashop.module.everpsblog.service.context_state
+
   prestashop.module.everpsblog.service.blog_image:
     class: PrestaShop\Module\Everpsblog\Service\BlogImageService
     arguments:


### PR DESCRIPTION
### Motivation
- Fix autowiring failure where controllers type-hinted `PrestaShop\Module\Everpsblog\Service\ContextStateService` couldn't be resolved to the existing service id `prestashop.module.everpsblog.service.context_state`.

### Description
- Added a class-based alias in `config/services.yml` mapping `PrestaShop\Module\Everpsblog\Service\ContextStateService` to `prestashop.module.everpsblog.service.context_state` so constructor autowiring works for admin controllers like `AuthorController`.

### Testing
- Ran `git diff --check` and `git status --short` to validate formatting and changes, and committed the update; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21d1637e48322a450d687f2343bed)