### PR TITLE
Fix DI autowiring for LegacyContextAdapter in module services

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -160,6 +160,9 @@ services:
   PrestaShop\Module\Everpsblog\Service\Audit\:
     resource: '../src/Service/Audit/*'
 
+  PrestaShop\Module\Everpsblog\Adapter\:
+    resource: '../src/Adapter/*'
+
   PrestaShop\Module\Everpsblog\Controller\Admin\:
     resource: '../src/Controller/Admin/*'
     public: true


### PR DESCRIPTION
### Motivation
- Symfony container failed to autowire `PrestaShop\Module\Everpsblog\Service\ContextStateService` because its constructor type-hinted `PrestaShop\Module\Everpsblog\Adapter\LegacyContextAdapter` but no service was registered for adapter classes.

### Description
- Register the `PrestaShop\Module\Everpsblog\Adapter\` namespace in `config/services.yml` with `resource: '../src/Adapter/*'` so adapter classes (including `LegacyContextAdapter`) are discovered and autowireable by the container, which resolves the `ContextStateService` dependency.

### Testing
- Ran `php -l src/Service/ContextStateService.php` and `php -l src/Adapter/LegacyContextAdapter.php`, and both reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21e04d12883229fb811e6e6124fa9)