### PR TITLE
Fix AuthorRepository autowiring alias

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -136,6 +136,10 @@ services:
     arguments:
       - 'PrestaShop\Module\Everpsblog\Entity\Author'
 
+
+  PrestaShop\Module\Everpsblog\Repository\AuthorRepository:
+    alias: prestashop.module.everpsblog.repository.author
+
   prestashop.module.everpsblog.repository.comment:
     class: PrestaShop\Module\Everpsblog\Repository\CommentRepository
     factory: ['@doctrine.orm.entity_manager', getRepository]


### PR DESCRIPTION
### Motivation
- Resolve an autowiring failure where `PrestaShop\Module\Everpsblog\Grid\Data\AuthorGridDataFactory` type-hints `PrestaShop\Module\Everpsblog\Repository\AuthorRepository` but only the service id `prestashop.module.everpsblog.repository.author` was registered.

### Description
- Add an alias in `config/services.yml` that maps `PrestaShop\Module\Everpsblog\Repository\AuthorRepository` to the existing `prestashop.module.everpsblog.repository.author` service so class type-hints resolve to the Doctrine repository service.

### Testing
- Ran `composer validate --no-check-publish`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21ebf04dc8322a077f93933c314e6)