### PR TITLE
Fix Symfony autowiring for Doctrine repository services

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -130,6 +130,16 @@ services:
     arguments:
       - 'PrestaShop\Module\Everpsblog\Entity\Tag'
 
+
+  PrestaShop\Module\Everpsblog\Repository\PostRepository:
+    alias: prestashop.module.everpsblog.repository.post
+
+  PrestaShop\Module\Everpsblog\Repository\CategoryRepository:
+    alias: prestashop.module.everpsblog.repository.category
+
+  PrestaShop\Module\Everpsblog\Repository\TagRepository:
+    alias: prestashop.module.everpsblog.repository.tag
+
   prestashop.module.everpsblog.repository.author:
     class: PrestaShop\Module\Everpsblog\Repository\AuthorRepository
     factory: ['@doctrine.orm.entity_manager', getRepository]
@@ -146,11 +156,17 @@ services:
     arguments:
       - 'PrestaShop\Module\Everpsblog\Entity\Comment'
 
+  PrestaShop\Module\Everpsblog\Repository\CommentRepository:
+    alias: prestashop.module.everpsblog.repository.comment
+
   prestashop.module.everpsblog.repository.image:
     class: PrestaShop\Module\Everpsblog\Repository\ImageRepository
     factory: ['@doctrine.orm.entity_manager', getRepository]
     arguments:
       - 'PrestaShop\Module\Everpsblog\Entity\Image'
+
+  PrestaShop\Module\Everpsblog\Repository\ImageRepository:
+    alias: prestashop.module.everpsblog.repository.image
 
   PrestaShop\Module\Everpsblog\Form\DataProvider\:
     resource: '../src/Form/DataProvider/*'


### PR DESCRIPTION
### Motivation
- Grid/data factories type-hint repository classes (e.g. `CategoryRepository`) but Doctrine repositories are registered under custom service IDs, causing Symfony autowiring failures. 
- Providing class-to-service aliases is required so the container can resolve constructor type-hints to the existing factory-based repository services. 
- The change prevents similar errors for other repositories used across the module.

### Description
- Updated `config/services.yml` to add explicit class-to-service aliases mapping `PrestaShop\Module\Everpsblog\Repository\PostRepository`, `PrestaShop\Module\Everpsblog\Repository\CategoryRepository`, `PrestaShop\Module\Everpsblog\Repository\TagRepository`, `PrestaShop\Module\Everpsblog\Repository\CommentRepository`, and `PrestaShop\Module\Everpsblog\Repository\ImageRepository` to their existing service IDs (e.g. `prestashop.module.everpsblog.repository.category`).
- Kept the original Doctrine factory-based service definitions (the `prestashop.module.everpsblog.repository.*` entries) intact so runtime behavior is unchanged except for autowiring resolution.
- No PHP code was modified; the fix is limited to service configuration to make autowiring robust for constructor-injected repositories.

### Testing
- Verified repository class usages with `rg` and confirmed constructors reference repository classes in grid/data factories, and these references are now covered by aliases; the check succeeded. 
- Inspected `config/services.yml` with `nl`/`sed` to confirm the new alias blocks are present and correctly reference the `prestashop.module.everpsblog.repository.*` services; the inspection succeeded. 
- No automated unit or integration tests were executed for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21f7170448322aee5036d4f55e04d)