### PR TITLE
Use class constants for Doctrine repositoryClass in blog entities

### DIFF
--- a/src/Entity/Author.php
+++ b/src/Entity/Author.php
@@ -4,9 +4,10 @@ namespace PrestaShop\Module\Everpsblog\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\AuthorRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\AuthorRepository")
+ * @ORM\Entity(repositoryClass=AuthorRepository::class)
  * @ORM\Table(name="ever_blog_author")
  */
 class Author

--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -4,9 +4,10 @@ namespace PrestaShop\Module\Everpsblog\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\CategoryRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\CategoryRepository")
+ * @ORM\Entity(repositoryClass=CategoryRepository::class)
  * @ORM\Table(name="ever_blog_category")
  */
 class Category

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -3,9 +3,10 @@
 namespace PrestaShop\Module\Everpsblog\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\CommentRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\CommentRepository")
+ * @ORM\Entity(repositoryClass=CommentRepository::class)
  * @ORM\Table(name="ever_blog_comments")
  */
 class Comment

--- a/src/Entity/Image.php
+++ b/src/Entity/Image.php
@@ -4,9 +4,10 @@ namespace PrestaShop\Module\Everpsblog\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\ImageRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\ImageRepository")
+ * @ORM\Entity(repositoryClass=ImageRepository::class)
  * @ORM\Table(name="ever_blog_image")
  */
 class Image

--- a/src/Entity/Post.php
+++ b/src/Entity/Post.php
@@ -6,9 +6,10 @@ use DateTimeInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\PostRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\PostRepository")
+ * @ORM\Entity(repositoryClass=PostRepository::class)
  * @ORM\Table(name="ever_blog_post")
  */
 class Post

--- a/src/Entity/Tag.php
+++ b/src/Entity/Tag.php
@@ -4,9 +4,10 @@ namespace PrestaShop\Module\Everpsblog\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use PrestaShop\Module\Everpsblog\Repository\TagRepository;
 
 /**
- * @ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\TagRepository")
+ * @ORM\Entity(repositoryClass=TagRepository::class)
  * @ORM\Table(name="ever_blog_tag")
  */
 class Tag


### PR DESCRIPTION
### Motivation
- Doctrine entity annotations referenced repository classes with escaped FQCN strings which can fail to resolve as real PHP classes in some environments. 
- Using class constants is a more robust, refactor-safe way to reference repository classes from annotations.

### Description
- Replaced `@ORM\Entity(repositoryClass="PrestaShop\\Module\\Everpsblog\\Repository\\...")` string references with `repositoryClass=...Repository::class` in the blog entities. 
- Added `use PrestaShop\Module\Everpsblog\Repository\...Repository;` imports to the `Post`, `Category`, `Author`, `Image`, `Comment`, and `Tag` entity files. 
- Updated entity files: `src/Entity/Post.php`, `src/Entity/Category.php`, `src/Entity/Author.php`, `src/Entity/Image.php`, `src/Entity/Comment.php`, and `src/Entity/Tag.php`.

### Testing
- Ran PHP syntax checks on updated entity files with `php -l src/Entity/Post.php`, `php -l src/Entity/Category.php`, `php -l src/Entity/Author.php`, `php -l src/Entity/Image.php`, `php -l src/Entity/Comment.php`, and `php -l src/Entity/Tag.php`, all of which reported no syntax errors. 
- Ran PHP syntax checks on repository files with `php -l src/Repository/*.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e220fa51e48322ad5eeb7e7d412c2f)