### PR TITLE
refactor(admin): remove unused denyBlogAccess wrapper

### DIFF
--- a/src/Controller/Admin/AbstractDomainController.php
+++ b/src/Controller/Admin/AbstractDomainController.php
@@ -25,8 +25,4 @@ abstract class AbstractDomainController extends FrameworkBundleAdminController
         return $this->contextStateService->getLanguageId();
     }
 
-    protected function denyBlogAccess(string $permission, string $resource): void
-    {
-        $this->denyAccessUnlessGranted($permission, $resource);
-    }
 }

--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -27,7 +27,7 @@ class AuthorController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_AUTHOR);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_AUTHOR);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,7 +37,7 @@ class AuthorController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $authorId = null): Response
     {
-        $this->denyBlogAccess($authorId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_AUTHOR);
+        $this->denyAccessUnlessGranted($authorId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_AUTHOR);
 
         $form = $this->createForm(AuthorType::class, $this->formDataProvider->getData($authorId));
         $form->handleRequest($request);

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -27,7 +27,7 @@ class CategoryController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_CATEGORY);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_CATEGORY);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,7 +37,7 @@ class CategoryController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $categoryId = null): Response
     {
-        $this->denyBlogAccess($categoryId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_CATEGORY);
+        $this->denyAccessUnlessGranted($categoryId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_CATEGORY);
 
         $form = $this->createForm(CategoryType::class, $this->formDataProvider->getData($categoryId));
         $form->handleRequest($request);

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -27,7 +27,7 @@ class CommentController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_COMMENT);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_COMMENT);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextLangId(), $request->query->all()),
@@ -37,7 +37,7 @@ class CommentController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $commentId = null): Response
     {
-        $this->denyBlogAccess($commentId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_COMMENT);
+        $this->denyAccessUnlessGranted($commentId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_COMMENT);
 
         $form = $this->createForm(CommentType::class, $this->formDataProvider->getData($commentId));
         $form->handleRequest($request);

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -9,7 +9,7 @@ class ConfigurationController extends AbstractDomainController
 {
     public function indexAction(): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_POST);
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/configuration.html.twig', [
             'postUrl' => $this->generateUrl('everpsblog_admin_post'),

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -44,7 +44,7 @@ class PostController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_POST);
 
         $definition = $this->definitionFactory->build();
         $data = $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all());
@@ -58,7 +58,7 @@ class PostController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $postId = null): Response
     {
-        $this->denyBlogAccess($postId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted($postId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_POST);
 
         $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId));
         $form->handleRequest($request);
@@ -72,7 +72,7 @@ class PostController extends AbstractDomainController
 
     public function createAction(Request $request): JsonResponse
     {
-        $this->denyBlogAccess(BlogPermission::CREATE, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted(BlogPermission::CREATE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_create');
 
         $command = $this->commandAssembler->assembleCreate($request->request->all());
@@ -83,7 +83,7 @@ class PostController extends AbstractDomainController
 
     public function updateAction(int $postId, Request $request): JsonResponse
     {
-        $this->denyBlogAccess(BlogPermission::UPDATE, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted(BlogPermission::UPDATE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_update_' . $postId);
 
         $command = $this->commandAssembler->assembleUpdate($postId, $request->request->all());
@@ -95,7 +95,7 @@ class PostController extends AbstractDomainController
 
     public function deleteAction(int $postId, Request $request): JsonResponse
     {
-        $this->denyBlogAccess(BlogPermission::DELETE, BlogPermission::RES_POST);
+        $this->denyAccessUnlessGranted(BlogPermission::DELETE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_delete_' . $postId);
 
         $this->commandBus->handle(new DeletePostCommand($postId));

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -27,7 +27,7 @@ class TagController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyBlogAccess(BlogPermission::READ, BlogPermission::RES_TAG);
+        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_TAG);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,7 +37,7 @@ class TagController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $tagId = null): Response
     {
-        $this->denyBlogAccess($tagId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_TAG);
+        $this->denyAccessUnlessGranted($tagId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_TAG);
 
         $form = $this->createForm(TagType::class, $this->formDataProvider->getData($tagId));
         $form->handleRequest($request);


### PR DESCRIPTION
### Motivation

- Simplify admin controllers by removing an unnecessary indirection that only forwarded to `denyAccessUnlessGranted`.
- Reduce surface area in `AbstractDomainController` and call the framework method directly to make intent explicit.

### Description

- Removed the `denyBlogAccess(string $permission, string $resource)` helper from `AbstractDomainController`.
- Replaced all calls to `$this->denyBlogAccess(...)` with direct `$this->denyAccessUnlessGranted(...)` calls in the admin controllers (`CategoryController`, `AuthorController`, `CommentController`, `ConfigurationController`, `TagController`, `PostController`).
- No permission logic was changed; this is a pure refactor to eliminate useless wrapper code.
- Changes were applied across the relevant files and committed with the message `refactor(admin): remove unused denyBlogAccess wrapper`.

### Testing

- Ran a search for remaining `denyBlogAccess(` usages with `rg -n "denyBlogAccess\(" src/Controller/Admin` and confirmed replacements.
- Ran PHP linting with `php -l` on the modified controller files and received no syntax errors.
- All automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e222036ab083229fa760635a51cde3)