### PR TITLE
refactor(admin): remove Back Office `denyAccessUnlessGranted` guards

### DIFF
--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -6,7 +6,6 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\AuthorFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\AuthorType;
 use PrestaShop\Module\Everpsblog\Grid\Data\AuthorGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\AuthorGridDefinitionFactory;
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +26,6 @@ class AuthorController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_AUTHOR);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,8 +35,6 @@ class AuthorController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $authorId = null): Response
     {
-        $this->denyAccessUnlessGranted($authorId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_AUTHOR);
-
         $form = $this->createForm(AuthorType::class, $this->formDataProvider->getData($authorId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -6,7 +6,6 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\CategoryFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CategoryType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CategoryGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CategoryGridDefinitionFactory;
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +26,6 @@ class CategoryController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_CATEGORY);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,8 +35,6 @@ class CategoryController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $categoryId = null): Response
     {
-        $this->denyAccessUnlessGranted($categoryId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_CATEGORY);
-
         $form = $this->createForm(CategoryType::class, $this->formDataProvider->getData($categoryId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -6,7 +6,6 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\CommentFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CommentType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CommentGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CommentGridDefinitionFactory;
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +26,6 @@ class CommentController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_COMMENT);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextLangId(), $request->query->all()),
@@ -37,8 +35,6 @@ class CommentController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $commentId = null): Response
     {
-        $this->denyAccessUnlessGranted($commentId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_COMMENT);
-
         $form = $this->createForm(CommentType::class, $this->formDataProvider->getData($commentId));
         $form->handleRequest($request);
 

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -2,15 +2,12 @@
 
 namespace PrestaShop\Module\Everpsblog\Controller\Admin;
 
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use Symfony\Component\HttpFoundation\Response;
 
 class ConfigurationController extends AbstractDomainController
 {
     public function indexAction(): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_POST);
-
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/configuration.html.twig', [
             'postUrl' => $this->generateUrl('everpsblog_admin_post'),
             'categoryUrl' => $this->generateUrl('everpsblog_admin_category'),

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -9,7 +9,6 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\PostFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\PostType;
 use PrestaShop\Module\Everpsblog\Grid\Data\PostGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\PostGridDefinitionFactory;
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -44,8 +43,6 @@ class PostController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_POST);
-
         $definition = $this->definitionFactory->build();
         $data = $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all());
 
@@ -58,8 +55,6 @@ class PostController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $postId = null): Response
     {
-        $this->denyAccessUnlessGranted($postId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_POST);
-
         $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId));
         $form->handleRequest($request);
 
@@ -72,7 +67,6 @@ class PostController extends AbstractDomainController
 
     public function createAction(Request $request): JsonResponse
     {
-        $this->denyAccessUnlessGranted(BlogPermission::CREATE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_create');
 
         $command = $this->commandAssembler->assembleCreate($request->request->all());
@@ -83,7 +77,6 @@ class PostController extends AbstractDomainController
 
     public function updateAction(int $postId, Request $request): JsonResponse
     {
-        $this->denyAccessUnlessGranted(BlogPermission::UPDATE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_update_' . $postId);
 
         $command = $this->commandAssembler->assembleUpdate($postId, $request->request->all());
@@ -95,7 +88,6 @@ class PostController extends AbstractDomainController
 
     public function deleteAction(int $postId, Request $request): JsonResponse
     {
-        $this->denyAccessUnlessGranted(BlogPermission::DELETE, BlogPermission::RES_POST);
         $this->validateCsrfToken($request, 'everpsblog_post_delete_' . $postId);
 
         $this->commandBus->handle(new DeletePostCommand($postId));

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -6,7 +6,6 @@ use PrestaShop\Module\Everpsblog\Form\DataProvider\TagFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\TagType;
 use PrestaShop\Module\Everpsblog\Grid\Data\TagGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\TagGridDefinitionFactory;
-use PrestaShop\Module\Everpsblog\Security\BlogPermission;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +26,6 @@ class TagController extends AbstractDomainController
 
     public function indexAction(Request $request): Response
     {
-        $this->denyAccessUnlessGranted(BlogPermission::READ, BlogPermission::RES_TAG);
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/resource.html.twig', [
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
@@ -37,8 +35,6 @@ class TagController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $tagId = null): Response
     {
-        $this->denyAccessUnlessGranted($tagId ? BlogPermission::UPDATE : BlogPermission::CREATE, BlogPermission::RES_TAG);
-
         $form = $this->createForm(TagType::class, $this->formDataProvider->getData($tagId));
         $form->handleRequest($request);
 


### PR DESCRIPTION
### Motivation

- Remove in-controller Back Office authorization checks to centralize or disable BO-specific permission handling as requested. 

### Description

- Deleted all `denyAccessUnlessGranted(...)` calls from admin controllers and removed now-unused `BlogPermission` imports. 
- Preserved CSRF validation and sensitive-action logging in write endpoints (create/update/delete) in `PostController`. 
- Updated files: `src/Controller/Admin/PostController.php`, `src/Controller/Admin/AuthorController.php`, `src/Controller/Admin/CategoryController.php`, `src/Controller/Admin/TagController.php`, `src/Controller/Admin/CommentController.php`, and `src/Controller/Admin/ConfigurationController.php`. 

### Testing

- Ran a search for remaining guards with `rg -n "denyAccessUnlessGranted" src/Controller/Admin` and found no matches. 
- Checked syntax on all modified files with `php -l` and confirmed there are no syntax errors. 
- Verified the modified files were updated and contain only the intended removals without altering other logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e222bec4388322899fcd3ad3216ae0)