### PR TITLE
Add admin cross-navigation and create-action buttons

### DIFF
--- a/src/Controller/Admin/AbstractDomainController.php
+++ b/src/Controller/Admin/AbstractDomainController.php
@@ -25,4 +25,16 @@ abstract class AbstractDomainController extends FrameworkBundleAdminController
         return $this->contextStateService->getLanguageId();
     }
 
+    protected function getAdminNavigationLinks(): array
+    {
+        return [
+            ['key' => 'post', 'label' => 'Articles', 'url' => $this->generateUrl('everpsblog_admin_post')],
+            ['key' => 'category', 'label' => 'Catégories', 'url' => $this->generateUrl('everpsblog_admin_category')],
+            ['key' => 'tag', 'label' => 'Tags', 'url' => $this->generateUrl('everpsblog_admin_tag')],
+            ['key' => 'author', 'label' => 'Auteurs', 'url' => $this->generateUrl('everpsblog_admin_author')],
+            ['key' => 'comment', 'label' => 'Commentaires', 'url' => $this->generateUrl('everpsblog_admin_comment')],
+            ['key' => 'configuration', 'label' => 'Configuration', 'url' => $this->generateUrl('everpsblog_admin_dashboard')],
+        ];
+    }
+
 }

--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -30,6 +30,9 @@ class AuthorController extends AbstractDomainController
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
             'resource' => 'author',
+            'currentResource' => 'author',
+            'createUrl' => $this->generateUrl('everpsblog_admin_author_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 
@@ -42,6 +45,9 @@ class AuthorController extends AbstractDomainController
             'resource' => 'author',
             'entityId' => $authorId,
             'form' => $form->createView(),
+            'currentResource' => 'author',
+            'createUrl' => $this->generateUrl('everpsblog_admin_author_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 }

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -30,6 +30,9 @@ class CategoryController extends AbstractDomainController
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
             'resource' => 'category',
+            'currentResource' => 'category',
+            'createUrl' => $this->generateUrl('everpsblog_admin_category_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 
@@ -42,6 +45,9 @@ class CategoryController extends AbstractDomainController
             'resource' => 'category',
             'entityId' => $categoryId,
             'form' => $form->createView(),
+            'currentResource' => 'category',
+            'createUrl' => $this->generateUrl('everpsblog_admin_category_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 }

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -30,6 +30,9 @@ class CommentController extends AbstractDomainController
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextLangId(), $request->query->all()),
             'resource' => 'comment',
+            'currentResource' => 'comment',
+            'createUrl' => $this->generateUrl('everpsblog_admin_comment_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 
@@ -42,6 +45,9 @@ class CommentController extends AbstractDomainController
             'resource' => 'comment',
             'entityId' => $commentId,
             'form' => $form->createView(),
+            'currentResource' => 'comment',
+            'createUrl' => $this->generateUrl('everpsblog_admin_comment_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 }

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -41,11 +41,8 @@ class ConfigurationController extends AbstractDomainController
         }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/configuration.html.twig', [
-            'postUrl' => $this->generateUrl('everpsblog_admin_post'),
-            'categoryUrl' => $this->generateUrl('everpsblog_admin_category'),
-            'tagUrl' => $this->generateUrl('everpsblog_admin_tag'),
-            'authorUrl' => $this->generateUrl('everpsblog_admin_author'),
-            'commentUrl' => $this->generateUrl('everpsblog_admin_comment'),
+            'currentResource' => 'configuration',
+            'navigationLinks' => $this->getAdminNavigationLinks(),
             'configurationForm' => $form->createView(),
         ]);
     }

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -50,6 +50,9 @@ class PostController extends AbstractDomainController
             'definition' => $definition,
             'data' => $data,
             'resource' => 'post',
+            'currentResource' => 'post',
+            'createUrl' => $this->generateUrl('everpsblog_admin_post_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 
@@ -62,6 +65,9 @@ class PostController extends AbstractDomainController
             'resource' => 'post',
             'entityId' => $postId,
             'form' => $form->createView(),
+            'currentResource' => 'post',
+            'createUrl' => $this->generateUrl('everpsblog_admin_post_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -30,6 +30,9 @@ class TagController extends AbstractDomainController
             'definition' => $this->definitionFactory->build(),
             'data' => $this->dataFactory->build($this->getContextShopId(), $this->getContextLangId(), $request->query->all()),
             'resource' => 'tag',
+            'currentResource' => 'tag',
+            'createUrl' => $this->generateUrl('everpsblog_admin_tag_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 
@@ -42,6 +45,9 @@ class TagController extends AbstractDomainController
             'resource' => 'tag',
             'entityId' => $tagId,
             'form' => $form->createView(),
+            'currentResource' => 'tag',
+            'createUrl' => $this->generateUrl('everpsblog_admin_tag_form'),
+            'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
     }
 }

--- a/views/templates/admin/modern/configuration.html.twig
+++ b/views/templates/admin/modern/configuration.html.twig
@@ -6,11 +6,9 @@
     <div class="card-body">
       <p class="mb-3">Le back-office Ever Blog utilise désormais des contrôleurs Symfony.</p>
       <div class="btn-group" role="group" aria-label="Ever Blog links">
-        <a class="btn btn-primary" href="{{ postUrl }}">Articles</a>
-        <a class="btn btn-outline-primary" href="{{ categoryUrl }}">Catégories</a>
-        <a class="btn btn-outline-primary" href="{{ tagUrl }}">Tags</a>
-        <a class="btn btn-outline-primary" href="{{ authorUrl }}">Auteurs</a>
-        <a class="btn btn-outline-primary" href="{{ commentUrl }}">Commentaires</a>
+        {% for link in navigationLinks %}
+          <a class="btn {{ currentResource == link.key ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ link.url }}">{{ link.label }}</a>
+        {% endfor %}
       </div>
     </div>
   </div>

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -4,6 +4,17 @@
   <div class="card">
     <h3 class="card-header">{{ resource|capitalize }} #{{ entityId ?: 'new' }}</h3>
     <div class="card-body">
+      <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+        <div class="btn-group mb-2" role="group" aria-label="Navigation Ever Blog">
+          {% for link in navigationLinks %}
+            <a class="btn {{ currentResource == link.key ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ link.url }}">{{ link.label }}</a>
+          {% endfor %}
+        </div>
+        {% if createUrl is defined and createUrl %}
+          <a class="btn btn-success mb-2" href="{{ createUrl }}">Ajouter un élément</a>
+        {% endif %}
+      </div>
+
       {{ form_start(form) }}
       {{ form_widget(form) }}
       <button type="submit" class="btn btn-primary">Enregistrer</button>

--- a/views/templates/admin/modern/resource.html.twig
+++ b/views/templates/admin/modern/resource.html.twig
@@ -4,6 +4,17 @@
   <div class="card">
     <h3 class="card-header">{{ definition.title }}</h3>
     <div class="card-body">
+      <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+        <div class="btn-group mb-2" role="group" aria-label="Navigation Ever Blog">
+          {% for link in navigationLinks %}
+            <a class="btn {{ currentResource == link.key ? 'btn-primary' : 'btn-outline-primary' }}" href="{{ link.url }}">{{ link.label }}</a>
+          {% endfor %}
+        </div>
+        {% if createUrl is defined and createUrl %}
+          <a class="btn btn-success mb-2" href="{{ createUrl }}">Ajouter un élément</a>
+        {% endif %}
+      </div>
+
       <form method="get" class="mb-3">
         <div class="row">
           {% for id, label in definition.filters %}


### PR DESCRIPTION
### Motivation
- Provide a consistent top navigation across all Ever Blog admin pages to allow quick switching between resources. 
- Expose a contextual “Ajouter un élément” (create) action from resource listing and form screens to simplify adding new items.

### Description
- Added a shared navigation builder `getAdminNavigationLinks()` in `src/Controller/Admin/AbstractDomainController.php` that returns link definitions for `post`, `category`, `tag`, `author`, `comment`, and `configuration`.
- Updated resource controllers (`src/Controller/Admin/PostController.php`, `CategoryController.php`, `TagController.php`, `AuthorController.php`, `CommentController.php`) to pass `currentResource`, `createUrl`, and `navigationLinks` to templates.
- Updated `src/Controller/Admin/ConfigurationController.php` to use the shared `navigationLinks` and `currentResource`.
- Updated admin templates to render the navigation and create button: `views/templates/admin/modern/resource.html.twig`, `form.html.twig`, and `configuration.html.twig` now render the navigation loop and a contextual `Ajouter un élément` button when `createUrl` is provided.

### Testing
- Ran PHP syntax checks with `php -l` on the modified controllers (`AbstractDomainController`, `PostController`, `CategoryController`, `AuthorController`, `TagController`, `CommentController`, `ConfigurationController`) and all files reported no syntax errors.
- Verified templates were updated to accept and render the new template variables (visual/manual verification not automated in this run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2277b20ec8322b5a65969c8fc53ee)