### PR TITLE
Unify admin post form submission and CSRF handling

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -16,7 +16,7 @@ everpsblog_admin_post:
 
 everpsblog_admin_post_form:
   path: /everpsblog/post/new
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\PostController::formAction'
     _legacy_controller: AdminEverPsBlogPost
@@ -24,7 +24,7 @@ everpsblog_admin_post_form:
 
 everpsblog_admin_post_edit:
   path: /everpsblog/post/{postId}/edit
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\PostController::formAction'
     _legacy_controller: AdminEverPsBlogPost

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -10,6 +10,7 @@ use PrestaShop\Module\Everpsblog\Form\Type\Admin\PostType;
 use PrestaShop\Module\Everpsblog\Grid\Data\PostGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\PostGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -58,12 +59,41 @@ class PostController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $postId = null): Response
     {
-        $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId));
+        $isEdit = null !== $postId;
+        $csrfTokenId = $isEdit ? 'everpsblog_post_update_' . $postId : 'everpsblog_post_create';
+        $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId), [
+            'method' => Request::METHOD_POST,
+            'action' => $isEdit
+                ? $this->generateUrl('everpsblog_admin_post_edit', ['postId' => $postId])
+                : $this->generateUrl('everpsblog_admin_post_form'),
+        ]);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $this->validateCsrfToken($request, $csrfTokenId);
+
+            if ($form->isValid()) {
+                $postData = (array) $form->getData();
+
+                try {
+                    $savedPostId = $isEdit
+                        ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $postId, $postData))
+                        : $this->commandBus->handle($this->commandAssembler->assembleCreate($postData));
+
+                    $this->addFlash('success', $isEdit ? 'Article mis à jour.' : 'Article créé.');
+
+                    return $this->redirectToRoute('everpsblog_admin_post_edit', ['postId' => $savedPostId]);
+                } catch (\Throwable $exception) {
+                    $form->addError(new FormError('Impossible d\'enregistrer l\'article.'));
+                    $this->addFlash('error', 'Impossible d\'enregistrer l\'article.');
+                }
+            }
+        }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/form.html.twig', [
             'resource' => 'post',
             'entityId' => $postId,
+            'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'post',
             'createUrl' => $this->generateUrl('everpsblog_admin_post_form'),
@@ -104,7 +134,11 @@ class PostController extends AbstractDomainController
 
     private function validateCsrfToken(Request $request, string $tokenId): void
     {
-        $token = (string) ($request->request->get('_csrf_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+        $token = (string) (
+            $request->request->get('_csrf_token')
+            ?: $request->request->get('_token')
+            ?: $request->headers->get('X-CSRF-TOKEN')
+        );
 
         if (!$this->isCsrfTokenValid($tokenId, $token)) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -16,6 +16,9 @@
       </div>
 
       {{ form_start(form) }}
+      {% if csrfTokenId is defined and csrfTokenId %}
+        <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrfTokenId) }}">
+      {% endif %}
       {{ form_widget(form) }}
       <button type="submit" class="btn btn-primary">Enregistrer</button>
       {{ form_end(form) }}


### PR DESCRIPTION
### Motivation
- Unifier le flux de soumission du formulaire d'administration des posts en choisissant le mode formulaire Symfony classique pour simplifier la logique et l'UX.
- Assurer une gestion cohérente du CSRF entre les actions create/update/delete en s'appuyant sur `isCsrfTokenValid` et des token IDs par action.
- Fournir un traitement serveur unique pour la création et la mise à jour (validation, assemblage des commandes et redirection) afin de réutiliser la logique existante du `CommandBus`.

### Description
- `src/Controller/Admin/PostController.php`: `formAction` gère désormais les soumissions `POST` pour create/update, calcule `csrfTokenId`, valide le token via `validateCsrfToken`, assemble et exécute les commandes create/update par le `PostCommandAssembler` et `CommandBus`, affiche des `flash` messages et redirige vers la page d'édition après sauvegarde, et ajoute `FormError` en cas d'erreur.
- `src/Controller/Admin/PostController.php`: `validateCsrfToken` accepte désormais le champ Symfony `_token` en plus de `_csrf_token` et du header `X-CSRF-TOKEN` avant d'appeler `isCsrfTokenValid`.
- `views/templates/admin/modern/form.html.twig`: injection explicite d'un champ caché `_csrf_token` généré avec `csrf_token(csrfTokenId)` lorsque `csrfTokenId` est fourni par le contrôleur.
- `config/routes.yml`: activation de la méthode `POST` sur les routes de formulaire `everpsblog_admin_post_form` et `everpsblog_admin_post_edit` pour que le formulaire classique soumette vers `formAction`.

### Testing
- `php -l src/Controller/Admin/PostController.php` a été exécuté et a renvoyé « No syntax errors detected ». 
- `git diff --check` a été exécuté pour vérifier les problèmes de formatage et n'a retourné aucune erreur.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22b1a84b08322bd9d0a599f3e7e0c)