### PR TITLE
Add CUD admin routes and command stack for Category/Tag/Author/Comment

### DIFF
--- a/config/routes.yml
+++ b/config/routes.yml
@@ -67,7 +67,7 @@ everpsblog_admin_category:
 
 everpsblog_admin_category_form:
   path: /everpsblog/category/new
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::formAction'
     _legacy_controller: AdminEverPsBlogCategory
@@ -75,7 +75,7 @@ everpsblog_admin_category_form:
 
 everpsblog_admin_category_edit:
   path: /everpsblog/category/{categoryId}/edit
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::formAction'
     _legacy_controller: AdminEverPsBlogCategory
@@ -93,7 +93,7 @@ everpsblog_admin_tag:
 
 everpsblog_admin_tag_form:
   path: /everpsblog/tag/new
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::formAction'
     _legacy_controller: AdminEverPsBlogTag
@@ -101,7 +101,7 @@ everpsblog_admin_tag_form:
 
 everpsblog_admin_tag_edit:
   path: /everpsblog/tag/{tagId}/edit
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::formAction'
     _legacy_controller: AdminEverPsBlogTag
@@ -119,7 +119,7 @@ everpsblog_admin_author:
 
 everpsblog_admin_author_form:
   path: /everpsblog/author/new
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::formAction'
     _legacy_controller: AdminEverPsBlogAuthor
@@ -127,7 +127,7 @@ everpsblog_admin_author_form:
 
 everpsblog_admin_author_edit:
   path: /everpsblog/author/{authorId}/edit
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::formAction'
     _legacy_controller: AdminEverPsBlogAuthor
@@ -145,7 +145,7 @@ everpsblog_admin_comment:
 
 everpsblog_admin_comment_form:
   path: /everpsblog/comment/new
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::formAction'
     _legacy_controller: AdminEverPsBlogComment
@@ -153,10 +153,118 @@ everpsblog_admin_comment_form:
 
 everpsblog_admin_comment_edit:
   path: /everpsblog/comment/{commentId}/edit
-  methods: [GET]
+  methods: [GET, POST]
   defaults:
     _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::formAction'
     _legacy_controller: AdminEverPsBlogComment
     _legacy_link: AdminEverPsBlogComment:edit
   requirements:
     commentId: '\d+'
+
+
+everpsblog_admin_category_create:
+  path: /everpsblog/category
+  methods: [POST]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::createAction'
+    _legacy_controller: AdminEverPsBlogCategory
+
+everpsblog_admin_category_update:
+  path: /everpsblog/category/{categoryId}
+  methods: [PUT]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::updateAction'
+    _legacy_controller: AdminEverPsBlogCategory
+  requirements:
+    categoryId: '\d+'
+
+everpsblog_admin_category_delete:
+  path: /everpsblog/category/{categoryId}
+  methods: [DELETE]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CategoryController::deleteAction'
+    _legacy_controller: AdminEverPsBlogCategory
+  requirements:
+    categoryId: '\d+'
+
+
+
+everpsblog_admin_tag_create:
+  path: /everpsblog/tag
+  methods: [POST]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::createAction'
+    _legacy_controller: AdminEverPsBlogTag
+
+everpsblog_admin_tag_update:
+  path: /everpsblog/tag/{tagId}
+  methods: [PUT]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::updateAction'
+    _legacy_controller: AdminEverPsBlogTag
+  requirements:
+    tagId: '\d+'
+
+everpsblog_admin_tag_delete:
+  path: /everpsblog/tag/{tagId}
+  methods: [DELETE]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\TagController::deleteAction'
+    _legacy_controller: AdminEverPsBlogTag
+  requirements:
+    tagId: '\d+'
+
+
+
+everpsblog_admin_author_create:
+  path: /everpsblog/author
+  methods: [POST]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::createAction'
+    _legacy_controller: AdminEverPsBlogAuthor
+
+everpsblog_admin_author_update:
+  path: /everpsblog/author/{authorId}
+  methods: [PUT]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::updateAction'
+    _legacy_controller: AdminEverPsBlogAuthor
+  requirements:
+    authorId: '\d+'
+
+everpsblog_admin_author_delete:
+  path: /everpsblog/author/{authorId}
+  methods: [DELETE]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\AuthorController::deleteAction'
+    _legacy_controller: AdminEverPsBlogAuthor
+  requirements:
+    authorId: '\d+'
+
+
+
+everpsblog_admin_comment_create:
+  path: /everpsblog/comment
+  methods: [POST]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::createAction'
+    _legacy_controller: AdminEverPsBlogComment
+
+everpsblog_admin_comment_update:
+  path: /everpsblog/comment/{commentId}
+  methods: [PUT]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::updateAction'
+    _legacy_controller: AdminEverPsBlogComment
+  requirements:
+    commentId: '\d+'
+
+everpsblog_admin_comment_delete:
+  path: /everpsblog/comment/{commentId}
+  methods: [DELETE]
+  defaults:
+    _controller: 'PrestaShop\Module\Everpsblog\Controller\Admin\CommentController::deleteAction'
+    _legacy_controller: AdminEverPsBlogComment
+  requirements:
+    commentId: '\d+'
+

--- a/config/services.yml
+++ b/config/services.yml
@@ -25,6 +25,26 @@ services:
     arguments:
       - '@doctrine.orm.entity_manager'
 
+  prestashop.module.everpsblog.blog.repository.category_write:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CategoryWriteRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
+
+  prestashop.module.everpsblog.blog.repository.tag_write:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\TagWriteRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
+
+  prestashop.module.everpsblog.blog.repository.author_write:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\AuthorWriteRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
+
+  prestashop.module.everpsblog.blog.repository.comment_write:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CommentWriteRepository
+    arguments:
+      - '@doctrine.orm.entity_manager'
+
   # ─────────────────────────────────────────────
   # HANDLERS
   # ─────────────────────────────────────────────
@@ -50,6 +70,66 @@ services:
       - '@doctrine.orm.entity_manager'
       - '@prestashop.module.everpsblog.blog.repository.post_write'
 
+  prestashop.module.everpsblog.blog.create_category_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\CreateCategoryHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.category_write'
+
+  prestashop.module.everpsblog.blog.update_category_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\UpdateCategoryHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.category_write'
+
+  prestashop.module.everpsblog.blog.delete_category_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\DeleteCategoryHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.category_write'
+
+  prestashop.module.everpsblog.blog.create_tag_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\CreateTagHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.tag_write'
+
+  prestashop.module.everpsblog.blog.update_tag_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\UpdateTagHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.tag_write'
+
+  prestashop.module.everpsblog.blog.delete_tag_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\DeleteTagHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.tag_write'
+
+  prestashop.module.everpsblog.blog.create_author_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\CreateAuthorHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.author_write'
+
+  prestashop.module.everpsblog.blog.update_author_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\UpdateAuthorHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.author_write'
+
+  prestashop.module.everpsblog.blog.delete_author_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\DeleteAuthorHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.author_write'
+
+  prestashop.module.everpsblog.blog.create_comment_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\CreateCommentHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.comment_write'
+
+  prestashop.module.everpsblog.blog.update_comment_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\UpdateCommentHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.comment_write'
+
+  prestashop.module.everpsblog.blog.delete_comment_handler:
+    class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\DeleteCommentHandler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.repository.comment_write'
+
   # ─────────────────────────────────────────────
   # COMMAND BUS
   # ─────────────────────────────────────────────
@@ -60,6 +140,18 @@ services:
         PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreatePostCommand: '@prestashop.module.everpsblog.blog.create_post_handler'
         PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdatePostCommand: '@prestashop.module.everpsblog.blog.update_post_handler'
         PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeletePostCommand: '@prestashop.module.everpsblog.blog.delete_post_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCategoryCommand: '@prestashop.module.everpsblog.blog.create_category_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCategoryCommand: '@prestashop.module.everpsblog.blog.update_category_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCategoryCommand: '@prestashop.module.everpsblog.blog.delete_category_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateTagCommand: '@prestashop.module.everpsblog.blog.create_tag_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateTagCommand: '@prestashop.module.everpsblog.blog.update_tag_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteTagCommand: '@prestashop.module.everpsblog.blog.delete_tag_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateAuthorCommand: '@prestashop.module.everpsblog.blog.create_author_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateAuthorCommand: '@prestashop.module.everpsblog.blog.update_author_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteAuthorCommand: '@prestashop.module.everpsblog.blog.delete_author_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCommentCommand: '@prestashop.module.everpsblog.blog.create_comment_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCommentCommand: '@prestashop.module.everpsblog.blog.update_comment_handler'
+        PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCommentCommand: '@prestashop.module.everpsblog.blog.delete_comment_handler'
 
   PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\CommandBusInterface:
     alias: prestashop.module.everpsblog.blog.command_bus
@@ -69,6 +161,18 @@ services:
   # ─────────────────────────────────────────────
   prestashop.module.everpsblog.blog.validator.post_request:
     class: PrestaShop\Module\Everpsblog\Application\Blog\PostRequestValidator
+
+  prestashop.module.everpsblog.blog.validator.category_request:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\CategoryRequestValidator
+
+  prestashop.module.everpsblog.blog.validator.tag_request:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\TagRequestValidator
+
+  prestashop.module.everpsblog.blog.validator.author_request:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\AuthorRequestValidator
+
+  prestashop.module.everpsblog.blog.validator.comment_request:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\CommentRequestValidator
 
   prestashop.module.everpsblog.blog.post_data_builder:
     class: PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler\PostCommandDataBuilder
@@ -84,6 +188,41 @@ services:
 
   PrestaShop\Module\Everpsblog\Application\Blog\PostCommandAssembler:
     alias: prestashop.module.everpsblog.blog.assembler.post_command
+
+  prestashop.module.everpsblog.blog.assembler.category_command:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\CategoryCommandAssembler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.validator.category_request'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+
+  prestashop.module.everpsblog.blog.assembler.tag_command:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\TagCommandAssembler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.validator.tag_request'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+
+  prestashop.module.everpsblog.blog.assembler.author_command:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\AuthorCommandAssembler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.validator.author_request'
+      - '@=service("prestashop.adapter.legacy.context").getContext().shop.id'
+
+  prestashop.module.everpsblog.blog.assembler.comment_command:
+    class: PrestaShop\Module\Everpsblog\Application\Blog\CommentCommandAssembler
+    arguments:
+      - '@prestashop.module.everpsblog.blog.validator.comment_request'
+
+  PrestaShop\Module\Everpsblog\Application\Blog\CategoryCommandAssembler:
+    alias: prestashop.module.everpsblog.blog.assembler.category_command
+
+  PrestaShop\Module\Everpsblog\Application\Blog\TagCommandAssembler:
+    alias: prestashop.module.everpsblog.blog.assembler.tag_command
+
+  PrestaShop\Module\Everpsblog\Application\Blog\AuthorCommandAssembler:
+    alias: prestashop.module.everpsblog.blog.assembler.author_command
+
+  PrestaShop\Module\Everpsblog\Application\Blog\CommentCommandAssembler:
+    alias: prestashop.module.everpsblog.blog.assembler.comment_command
 
   # ─────────────────────────────────────────────
   # SERVICES

--- a/src/Application/Blog/AuthorCommandAssembler.php
+++ b/src/Application/Blog/AuthorCommandAssembler.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateAuthorCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateAuthorCommand;
+
+class AuthorCommandAssembler
+{
+    /** @var AuthorRequestValidator */
+    private $validator;
+
+    /** @var int */
+    private $shopId;
+
+    public function __construct(AuthorRequestValidator $validator, int $shopId)
+    {
+        $this->validator = $validator;
+        $this->shopId = $shopId;
+    }
+
+    public function assembleCreate(array $requestData): CreateAuthorCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new CreateAuthorCommand($this->mergeDefaults($validatedData));
+    }
+
+    public function assembleUpdate(int $authorId, array $requestData): UpdateAuthorCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new UpdateAuthorCommand($authorId, $this->mergeDefaults($validatedData));
+    }
+
+    private function mergeDefaults(array $data): array
+    {
+        return array_merge([
+            'id_shop' => $this->shopId,
+            'id_employee' => 0,
+            'nickhandle' => '',
+            'bio' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'active' => 1,
+            'indexable' => 1,
+            'follow' => 1,
+            'sitemap' => 1,
+        ], $data);
+    }
+}

--- a/src/Application/Blog/AuthorRequestValidator.php
+++ b/src/Application/Blog/AuthorRequestValidator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+class AuthorRequestValidator
+{
+    public function validate(array $requestData): array
+    {
+        return $requestData;
+    }
+}

--- a/src/Application/Blog/CategoryCommandAssembler.php
+++ b/src/Application/Blog/CategoryCommandAssembler.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCategoryCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCategoryCommand;
+
+class CategoryCommandAssembler
+{
+    /** @var CategoryRequestValidator */
+    private $validator;
+
+    /** @var int */
+    private $shopId;
+
+    public function __construct(CategoryRequestValidator $validator, int $shopId)
+    {
+        $this->validator = $validator;
+        $this->shopId = $shopId;
+    }
+
+    public function assembleCreate(array $requestData): CreateCategoryCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new CreateCategoryCommand($this->mergeDefaults($validatedData));
+    }
+
+    public function assembleUpdate(int $categoryId, array $requestData): UpdateCategoryCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new UpdateCategoryCommand($categoryId, $this->mergeDefaults($validatedData));
+    }
+
+    private function mergeDefaults(array $data): array
+    {
+        return array_merge([
+            'id_shop' => $this->shopId,
+            'title' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'content' => '',
+            'bottom_content' => '',
+            'active' => 1,
+            'indexable' => 1,
+            'follow' => 1,
+            'sitemap' => 1,
+            'id_parent_category' => null,
+            'is_root_category' => 0,
+        ], $data);
+    }
+}

--- a/src/Application/Blog/CategoryRequestValidator.php
+++ b/src/Application/Blog/CategoryRequestValidator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+class CategoryRequestValidator
+{
+    public function validate(array $requestData): array
+    {
+        return $requestData;
+    }
+}

--- a/src/Application/Blog/CommentCommandAssembler.php
+++ b/src/Application/Blog/CommentCommandAssembler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCommentCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCommentCommand;
+
+class CommentCommandAssembler
+{
+    /** @var CommentRequestValidator */
+    private $validator;
+
+    public function __construct(CommentRequestValidator $validator)
+    {
+        $this->validator = $validator;
+    }
+
+    public function assembleCreate(array $requestData): CreateCommentCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new CreateCommentCommand($this->mergeDefaults($validatedData));
+    }
+
+    public function assembleUpdate(int $commentId, array $requestData): UpdateCommentCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new UpdateCommentCommand($commentId, $this->mergeDefaults($validatedData));
+    }
+
+    private function mergeDefaults(array $data): array
+    {
+        return array_merge([
+            'id_lang' => 0,
+            'comment' => (string) ($data['content'] ?? ''),
+            'name' => (string) ($data['nickname'] ?? ''),
+            'user_email' => '',
+            'active' => 1,
+        ], $data);
+    }
+}

--- a/src/Application/Blog/CommentRequestValidator.php
+++ b/src/Application/Blog/CommentRequestValidator.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use InvalidArgumentException;
+
+class CommentRequestValidator
+{
+    public function validate(array $requestData): array
+    {
+        if (empty($requestData['id_ever_post'])) {
+            throw new InvalidArgumentException('id_ever_post is required for comment commands.');
+        }
+
+        return $requestData;
+    }
+}

--- a/src/Application/Blog/TagCommandAssembler.php
+++ b/src/Application/Blog/TagCommandAssembler.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateTagCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateTagCommand;
+
+class TagCommandAssembler
+{
+    /** @var TagRequestValidator */
+    private $validator;
+
+    /** @var int */
+    private $shopId;
+
+    public function __construct(TagRequestValidator $validator, int $shopId)
+    {
+        $this->validator = $validator;
+        $this->shopId = $shopId;
+    }
+
+    public function assembleCreate(array $requestData): CreateTagCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new CreateTagCommand($this->mergeDefaults($validatedData));
+    }
+
+    public function assembleUpdate(int $tagId, array $requestData): UpdateTagCommand
+    {
+        $validatedData = $this->validator->validate($requestData);
+
+        return new UpdateTagCommand($tagId, $this->mergeDefaults($validatedData));
+    }
+
+    private function mergeDefaults(array $data): array
+    {
+        return array_merge([
+            'id_shop' => $this->shopId,
+            'title' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'content' => '',
+            'bottom_content' => '',
+            'active' => 1,
+            'indexable' => 1,
+            'follow' => 1,
+            'sitemap' => 1,
+        ], $data);
+    }
+}

--- a/src/Application/Blog/TagRequestValidator.php
+++ b/src/Application/Blog/TagRequestValidator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+class TagRequestValidator
+{
+    public function validate(array $requestData): array
+    {
+        return $requestData;
+    }
+}

--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -2,23 +2,32 @@
 
 namespace PrestaShop\Module\Everpsblog\Controller\Admin;
 
+use PrestaShop\Module\Everpsblog\Application\Blog\AuthorCommandAssembler;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteAuthorCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\CommandBusInterface;
 use PrestaShop\Module\Everpsblog\Form\DataProvider\AuthorFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\AuthorType;
 use PrestaShop\Module\Everpsblog\Grid\Data\AuthorGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\AuthorGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthorController extends AbstractDomainController
 {
+    private $commandBus;
+    private $commandAssembler;
     private $definitionFactory;
     private $dataFactory;
     private $formDataProvider;
 
-    public function __construct(ContextStateService $contextStateService, AuthorGridDefinitionFactory $definitionFactory, AuthorGridDataFactory $dataFactory, AuthorFormDataProvider $formDataProvider)
+    public function __construct(ContextStateService $contextStateService, CommandBusInterface $commandBus, AuthorCommandAssembler $commandAssembler, AuthorGridDefinitionFactory $definitionFactory, AuthorGridDataFactory $dataFactory, AuthorFormDataProvider $formDataProvider)
     {
         parent::__construct($contextStateService);
+        $this->commandBus = $commandBus;
+        $this->commandAssembler = $commandAssembler;
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
@@ -38,16 +47,79 @@ class AuthorController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $authorId = null): Response
     {
-        $form = $this->createForm(AuthorType::class, $this->formDataProvider->getData($authorId));
+        $isEdit = null !== $authorId;
+        $csrfTokenId = $isEdit ? 'everpsblog_author_update_' . $authorId : 'everpsblog_author_create';
+
+        $form = $this->createForm(AuthorType::class, $this->formDataProvider->getData($authorId), [
+            'method' => Request::METHOD_POST,
+            'action' => $isEdit
+                ? $this->generateUrl('everpsblog_admin_author_edit', ['authorId' => $authorId])
+                : $this->generateUrl('everpsblog_admin_author_form'),
+        ]);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $this->validateCsrfToken($request, $csrfTokenId);
+
+            if ($form->isValid()) {
+                try {
+                    $savedAuthorId = $isEdit
+                        ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $authorId, (array) $form->getData()))
+                        : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+
+                    $this->addFlash('success', $isEdit ? 'Auteur mis à jour.' : 'Auteur créé.');
+
+                    return $this->redirectToRoute('everpsblog_admin_author_edit', ['authorId' => $savedAuthorId]);
+                } catch (\Throwable $exception) {
+                    $form->addError(new FormError('Impossible d\'enregistrer l\'auteur.'));
+                }
+            }
+        }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/form.html.twig', [
             'resource' => 'author',
             'entityId' => $authorId,
+            'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'author',
             'createUrl' => $this->generateUrl('everpsblog_admin_author_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
+    }
+
+    public function createAction(Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_author_create');
+
+        $authorId = $this->commandBus->handle($this->commandAssembler->assembleCreate($request->request->all()));
+
+        return new JsonResponse(['id_ever_author' => $authorId], JsonResponse::HTTP_CREATED);
+    }
+
+    public function updateAction(int $authorId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_author_update_' . $authorId);
+
+        $updatedAuthorId = $this->commandBus->handle($this->commandAssembler->assembleUpdate($authorId, $request->request->all()));
+
+        return new JsonResponse(['id_ever_author' => $updatedAuthorId], JsonResponse::HTTP_OK);
+    }
+
+    public function deleteAction(int $authorId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_author_delete_' . $authorId);
+
+        $this->commandBus->handle(new DeleteAuthorCommand($authorId));
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function validateCsrfToken(Request $request, string $tokenId): void
+    {
+        $token = (string) ($request->request->get('_csrf_token') ?: $request->request->get('_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+
+        if (!$this->isCsrfTokenValid($tokenId, $token)) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
     }
 }

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -2,23 +2,32 @@
 
 namespace PrestaShop\Module\Everpsblog\Controller\Admin;
 
+use PrestaShop\Module\Everpsblog\Application\Blog\CategoryCommandAssembler;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCategoryCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\CommandBusInterface;
 use PrestaShop\Module\Everpsblog\Form\DataProvider\CategoryFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CategoryType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CategoryGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CategoryGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CategoryController extends AbstractDomainController
 {
+    private $commandBus;
+    private $commandAssembler;
     private $definitionFactory;
     private $dataFactory;
     private $formDataProvider;
 
-    public function __construct(ContextStateService $contextStateService, CategoryGridDefinitionFactory $definitionFactory, CategoryGridDataFactory $dataFactory, CategoryFormDataProvider $formDataProvider)
+    public function __construct(ContextStateService $contextStateService, CommandBusInterface $commandBus, CategoryCommandAssembler $commandAssembler, CategoryGridDefinitionFactory $definitionFactory, CategoryGridDataFactory $dataFactory, CategoryFormDataProvider $formDataProvider)
     {
         parent::__construct($contextStateService);
+        $this->commandBus = $commandBus;
+        $this->commandAssembler = $commandAssembler;
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
@@ -38,16 +47,81 @@ class CategoryController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $categoryId = null): Response
     {
-        $form = $this->createForm(CategoryType::class, $this->formDataProvider->getData($categoryId));
+        $isEdit = null !== $categoryId;
+        $csrfTokenId = $isEdit ? 'everpsblog_category_update_' . $categoryId : 'everpsblog_category_create';
+
+        $form = $this->createForm(CategoryType::class, $this->formDataProvider->getData($categoryId), [
+            'method' => Request::METHOD_POST,
+            'action' => $isEdit
+                ? $this->generateUrl('everpsblog_admin_category_edit', ['categoryId' => $categoryId])
+                : $this->generateUrl('everpsblog_admin_category_form'),
+        ]);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $this->validateCsrfToken($request, $csrfTokenId);
+
+            if ($form->isValid()) {
+                $data = (array) $form->getData();
+
+                try {
+                    $savedCategoryId = $isEdit
+                        ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $categoryId, $data))
+                        : $this->commandBus->handle($this->commandAssembler->assembleCreate($data));
+
+                    $this->addFlash('success', $isEdit ? 'Catégorie mise à jour.' : 'Catégorie créée.');
+
+                    return $this->redirectToRoute('everpsblog_admin_category_edit', ['categoryId' => $savedCategoryId]);
+                } catch (\Throwable $exception) {
+                    $form->addError(new FormError('Impossible d\'enregistrer la catégorie.'));
+                }
+            }
+        }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/form.html.twig', [
             'resource' => 'category',
             'entityId' => $categoryId,
+            'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'category',
             'createUrl' => $this->generateUrl('everpsblog_admin_category_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
+    }
+
+    public function createAction(Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_category_create');
+
+        $categoryId = $this->commandBus->handle($this->commandAssembler->assembleCreate($request->request->all()));
+
+        return new JsonResponse(['id_ever_category' => $categoryId], JsonResponse::HTTP_CREATED);
+    }
+
+    public function updateAction(int $categoryId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_category_update_' . $categoryId);
+
+        $updatedCategoryId = $this->commandBus->handle($this->commandAssembler->assembleUpdate($categoryId, $request->request->all()));
+
+        return new JsonResponse(['id_ever_category' => $updatedCategoryId], JsonResponse::HTTP_OK);
+    }
+
+    public function deleteAction(int $categoryId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_category_delete_' . $categoryId);
+
+        $this->commandBus->handle(new DeleteCategoryCommand($categoryId));
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function validateCsrfToken(Request $request, string $tokenId): void
+    {
+        $token = (string) ($request->request->get('_csrf_token') ?: $request->request->get('_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+
+        if (!$this->isCsrfTokenValid($tokenId, $token)) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
     }
 }

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -2,23 +2,32 @@
 
 namespace PrestaShop\Module\Everpsblog\Controller\Admin;
 
+use PrestaShop\Module\Everpsblog\Application\Blog\CommentCommandAssembler;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCommentCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\CommandBusInterface;
 use PrestaShop\Module\Everpsblog\Form\DataProvider\CommentFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\CommentType;
 use PrestaShop\Module\Everpsblog\Grid\Data\CommentGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\CommentGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class CommentController extends AbstractDomainController
 {
+    private $commandBus;
+    private $commandAssembler;
     private $definitionFactory;
     private $dataFactory;
     private $formDataProvider;
 
-    public function __construct(ContextStateService $contextStateService, CommentGridDefinitionFactory $definitionFactory, CommentGridDataFactory $dataFactory, CommentFormDataProvider $formDataProvider)
+    public function __construct(ContextStateService $contextStateService, CommandBusInterface $commandBus, CommentCommandAssembler $commandAssembler, CommentGridDefinitionFactory $definitionFactory, CommentGridDataFactory $dataFactory, CommentFormDataProvider $formDataProvider)
     {
         parent::__construct($contextStateService);
+        $this->commandBus = $commandBus;
+        $this->commandAssembler = $commandAssembler;
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
@@ -38,16 +47,79 @@ class CommentController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $commentId = null): Response
     {
-        $form = $this->createForm(CommentType::class, $this->formDataProvider->getData($commentId));
+        $isEdit = null !== $commentId;
+        $csrfTokenId = $isEdit ? 'everpsblog_comment_update_' . $commentId : 'everpsblog_comment_create';
+
+        $form = $this->createForm(CommentType::class, $this->formDataProvider->getData($commentId), [
+            'method' => Request::METHOD_POST,
+            'action' => $isEdit
+                ? $this->generateUrl('everpsblog_admin_comment_edit', ['commentId' => $commentId])
+                : $this->generateUrl('everpsblog_admin_comment_form'),
+        ]);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $this->validateCsrfToken($request, $csrfTokenId);
+
+            if ($form->isValid()) {
+                try {
+                    $savedCommentId = $isEdit
+                        ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $commentId, (array) $form->getData()))
+                        : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+
+                    $this->addFlash('success', $isEdit ? 'Commentaire mis à jour.' : 'Commentaire créé.');
+
+                    return $this->redirectToRoute('everpsblog_admin_comment_edit', ['commentId' => $savedCommentId]);
+                } catch (\Throwable $exception) {
+                    $form->addError(new FormError('Impossible d\'enregistrer le commentaire.'));
+                }
+            }
+        }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/form.html.twig', [
             'resource' => 'comment',
             'entityId' => $commentId,
+            'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'comment',
             'createUrl' => $this->generateUrl('everpsblog_admin_comment_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
+    }
+
+    public function createAction(Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_comment_create');
+
+        $commentId = $this->commandBus->handle($this->commandAssembler->assembleCreate($request->request->all()));
+
+        return new JsonResponse(['id_ever_comment' => $commentId], JsonResponse::HTTP_CREATED);
+    }
+
+    public function updateAction(int $commentId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_comment_update_' . $commentId);
+
+        $updatedCommentId = $this->commandBus->handle($this->commandAssembler->assembleUpdate($commentId, $request->request->all()));
+
+        return new JsonResponse(['id_ever_comment' => $updatedCommentId], JsonResponse::HTTP_OK);
+    }
+
+    public function deleteAction(int $commentId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_comment_delete_' . $commentId);
+
+        $this->commandBus->handle(new DeleteCommentCommand($commentId));
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function validateCsrfToken(Request $request, string $tokenId): void
+    {
+        $token = (string) ($request->request->get('_csrf_token') ?: $request->request->get('_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+
+        if (!$this->isCsrfTokenValid($tokenId, $token)) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
     }
 }

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -2,23 +2,32 @@
 
 namespace PrestaShop\Module\Everpsblog\Controller\Admin;
 
+use PrestaShop\Module\Everpsblog\Application\Blog\TagCommandAssembler;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteTagCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandBus\CommandBusInterface;
 use PrestaShop\Module\Everpsblog\Form\DataProvider\TagFormDataProvider;
 use PrestaShop\Module\Everpsblog\Form\Type\Admin\TagType;
 use PrestaShop\Module\Everpsblog\Grid\Data\TagGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\TagGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\ContextStateService;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class TagController extends AbstractDomainController
 {
+    private $commandBus;
+    private $commandAssembler;
     private $definitionFactory;
     private $dataFactory;
     private $formDataProvider;
 
-    public function __construct(ContextStateService $contextStateService, TagGridDefinitionFactory $definitionFactory, TagGridDataFactory $dataFactory, TagFormDataProvider $formDataProvider)
+    public function __construct(ContextStateService $contextStateService, CommandBusInterface $commandBus, TagCommandAssembler $commandAssembler, TagGridDefinitionFactory $definitionFactory, TagGridDataFactory $dataFactory, TagFormDataProvider $formDataProvider)
     {
         parent::__construct($contextStateService);
+        $this->commandBus = $commandBus;
+        $this->commandAssembler = $commandAssembler;
         $this->definitionFactory = $definitionFactory;
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
@@ -38,16 +47,79 @@ class TagController extends AbstractDomainController
 
     public function formAction(Request $request, ?int $tagId = null): Response
     {
-        $form = $this->createForm(TagType::class, $this->formDataProvider->getData($tagId));
+        $isEdit = null !== $tagId;
+        $csrfTokenId = $isEdit ? 'everpsblog_tag_update_' . $tagId : 'everpsblog_tag_create';
+
+        $form = $this->createForm(TagType::class, $this->formDataProvider->getData($tagId), [
+            'method' => Request::METHOD_POST,
+            'action' => $isEdit
+                ? $this->generateUrl('everpsblog_admin_tag_edit', ['tagId' => $tagId])
+                : $this->generateUrl('everpsblog_admin_tag_form'),
+        ]);
         $form->handleRequest($request);
+
+        if ($form->isSubmitted()) {
+            $this->validateCsrfToken($request, $csrfTokenId);
+
+            if ($form->isValid()) {
+                try {
+                    $savedTagId = $isEdit
+                        ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $tagId, (array) $form->getData()))
+                        : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+
+                    $this->addFlash('success', $isEdit ? 'Tag mis à jour.' : 'Tag créé.');
+
+                    return $this->redirectToRoute('everpsblog_admin_tag_edit', ['tagId' => $savedTagId]);
+                } catch (\Throwable $exception) {
+                    $form->addError(new FormError('Impossible d\'enregistrer le tag.'));
+                }
+            }
+        }
 
         return $this->render('@Modules/everpsblog/views/templates/admin/modern/form.html.twig', [
             'resource' => 'tag',
             'entityId' => $tagId,
+            'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'tag',
             'createUrl' => $this->generateUrl('everpsblog_admin_tag_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);
+    }
+
+    public function createAction(Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_tag_create');
+
+        $tagId = $this->commandBus->handle($this->commandAssembler->assembleCreate($request->request->all()));
+
+        return new JsonResponse(['id_ever_tag' => $tagId], JsonResponse::HTTP_CREATED);
+    }
+
+    public function updateAction(int $tagId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_tag_update_' . $tagId);
+
+        $updatedTagId = $this->commandBus->handle($this->commandAssembler->assembleUpdate($tagId, $request->request->all()));
+
+        return new JsonResponse(['id_ever_tag' => $updatedTagId], JsonResponse::HTTP_OK);
+    }
+
+    public function deleteAction(int $tagId, Request $request): JsonResponse
+    {
+        $this->validateCsrfToken($request, 'everpsblog_tag_delete_' . $tagId);
+
+        $this->commandBus->handle(new DeleteTagCommand($tagId));
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function validateCsrfToken(Request $request, string $tokenId): void
+    {
+        $token = (string) ($request->request->get('_csrf_token') ?: $request->request->get('_token') ?: $request->headers->get('X-CSRF-TOKEN'));
+
+        if (!$this->isCsrfTokenValid($tokenId, $token)) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
     }
 }

--- a/src/Core/Domain/Blog/Command/CreateAuthorCommand.php
+++ b/src/Core/Domain/Blog/Command/CreateAuthorCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class CreateAuthorCommand
+{
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/CreateCategoryCommand.php
+++ b/src/Core/Domain/Blog/Command/CreateCategoryCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class CreateCategoryCommand
+{
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/CreateCommentCommand.php
+++ b/src/Core/Domain/Blog/Command/CreateCommentCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class CreateCommentCommand
+{
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/CreateTagCommand.php
+++ b/src/Core/Domain/Blog/Command/CreateTagCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class CreateTagCommand
+{
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/DeleteAuthorCommand.php
+++ b/src/Core/Domain/Blog/Command/DeleteAuthorCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class DeleteAuthorCommand
+{
+    /** @var int */
+    private $authorId;
+
+    public function __construct(int $authorId)
+    {
+        $this->authorId = $authorId;
+    }
+
+    public function getAuthorId(): int
+    {
+        return $this->authorId;
+    }
+}

--- a/src/Core/Domain/Blog/Command/DeleteCategoryCommand.php
+++ b/src/Core/Domain/Blog/Command/DeleteCategoryCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class DeleteCategoryCommand
+{
+    /** @var int */
+    private $categoryId;
+
+    public function __construct(int $categoryId)
+    {
+        $this->categoryId = $categoryId;
+    }
+
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+}

--- a/src/Core/Domain/Blog/Command/DeleteCommentCommand.php
+++ b/src/Core/Domain/Blog/Command/DeleteCommentCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class DeleteCommentCommand
+{
+    /** @var int */
+    private $commentId;
+
+    public function __construct(int $commentId)
+    {
+        $this->commentId = $commentId;
+    }
+
+    public function getCommentId(): int
+    {
+        return $this->commentId;
+    }
+}

--- a/src/Core/Domain/Blog/Command/DeleteTagCommand.php
+++ b/src/Core/Domain/Blog/Command/DeleteTagCommand.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class DeleteTagCommand
+{
+    /** @var int */
+    private $tagId;
+
+    public function __construct(int $tagId)
+    {
+        $this->tagId = $tagId;
+    }
+
+    public function getTagId(): int
+    {
+        return $this->tagId;
+    }
+}

--- a/src/Core/Domain/Blog/Command/UpdateAuthorCommand.php
+++ b/src/Core/Domain/Blog/Command/UpdateAuthorCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class UpdateAuthorCommand
+{
+    /** @var int */
+    private $authorId;
+
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(int $authorId, array $data)
+    {
+        $this->authorId = $authorId;
+        $this->data = $data;
+    }
+
+    public function getAuthorId(): int
+    {
+        return $this->authorId;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/UpdateCategoryCommand.php
+++ b/src/Core/Domain/Blog/Command/UpdateCategoryCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class UpdateCategoryCommand
+{
+    /** @var int */
+    private $categoryId;
+
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(int $categoryId, array $data)
+    {
+        $this->categoryId = $categoryId;
+        $this->data = $data;
+    }
+
+    public function getCategoryId(): int
+    {
+        return $this->categoryId;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/UpdateCommentCommand.php
+++ b/src/Core/Domain/Blog/Command/UpdateCommentCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class UpdateCommentCommand
+{
+    /** @var int */
+    private $commentId;
+
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(int $commentId, array $data)
+    {
+        $this->commentId = $commentId;
+        $this->data = $data;
+    }
+
+    public function getCommentId(): int
+    {
+        return $this->commentId;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/Command/UpdateTagCommand.php
+++ b/src/Core/Domain/Blog/Command/UpdateTagCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command;
+
+class UpdateTagCommand
+{
+    /** @var int */
+    private $tagId;
+
+    /** @var array<string, mixed> */
+    private $data;
+
+    public function __construct(int $tagId, array $data)
+    {
+        $this->tagId = $tagId;
+        $this->data = $data;
+    }
+
+    public function getTagId(): int
+    {
+        return $this->tagId;
+    }
+
+    public function getData(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/CreateAuthorHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/CreateAuthorHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateAuthorCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\AuthorWriteRepository;
+
+class CreateAuthorHandler
+{
+    /** @var AuthorWriteRepository */
+    private $repository;
+
+    public function __construct(AuthorWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(CreateAuthorCommand $command): int
+    {
+        return $this->repository->create($command->getData());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/CreateCategoryHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/CreateCategoryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCategoryCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CategoryWriteRepository;
+
+class CreateCategoryHandler
+{
+    /** @var CategoryWriteRepository */
+    private $repository;
+
+    public function __construct(CategoryWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(CreateCategoryCommand $command): int
+    {
+        return $this->repository->create($command->getData());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/CreateCommentHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/CreateCommentHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateCommentCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CommentWriteRepository;
+
+class CreateCommentHandler
+{
+    /** @var CommentWriteRepository */
+    private $repository;
+
+    public function __construct(CommentWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(CreateCommentCommand $command): int
+    {
+        return $this->repository->create($command->getData());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/CreateTagHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/CreateTagHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\CreateTagCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\TagWriteRepository;
+
+class CreateTagHandler
+{
+    /** @var TagWriteRepository */
+    private $repository;
+
+    public function __construct(TagWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(CreateTagCommand $command): int
+    {
+        return $this->repository->create($command->getData());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/DeleteAuthorHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/DeleteAuthorHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteAuthorCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\AuthorWriteRepository;
+
+class DeleteAuthorHandler
+{
+    /** @var AuthorWriteRepository */
+    private $repository;
+
+    public function __construct(AuthorWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(DeleteAuthorCommand $command): void
+    {
+        $this->repository->delete($command->getAuthorId());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/DeleteCategoryHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/DeleteCategoryHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCategoryCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CategoryWriteRepository;
+
+class DeleteCategoryHandler
+{
+    /** @var CategoryWriteRepository */
+    private $repository;
+
+    public function __construct(CategoryWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(DeleteCategoryCommand $command): void
+    {
+        $this->repository->delete($command->getCategoryId());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/DeleteCommentHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/DeleteCommentHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteCommentCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CommentWriteRepository;
+
+class DeleteCommentHandler
+{
+    /** @var CommentWriteRepository */
+    private $repository;
+
+    public function __construct(CommentWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(DeleteCommentCommand $command): void
+    {
+        $this->repository->delete($command->getCommentId());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/DeleteTagHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/DeleteTagHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\DeleteTagCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\TagWriteRepository;
+
+class DeleteTagHandler
+{
+    /** @var TagWriteRepository */
+    private $repository;
+
+    public function __construct(TagWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(DeleteTagCommand $command): void
+    {
+        $this->repository->delete($command->getTagId());
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/UpdateAuthorHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/UpdateAuthorHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateAuthorCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\AuthorWriteRepository;
+
+class UpdateAuthorHandler
+{
+    /** @var AuthorWriteRepository */
+    private $repository;
+
+    public function __construct(AuthorWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(UpdateAuthorCommand $command): int
+    {
+        $this->repository->update($command->getAuthorId(), $command->getData());
+
+        return $command->getAuthorId();
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/UpdateCategoryHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/UpdateCategoryHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCategoryCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CategoryWriteRepository;
+
+class UpdateCategoryHandler
+{
+    /** @var CategoryWriteRepository */
+    private $repository;
+
+    public function __construct(CategoryWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(UpdateCategoryCommand $command): int
+    {
+        $this->repository->update($command->getCategoryId(), $command->getData());
+
+        return $command->getCategoryId();
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/UpdateCommentHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/UpdateCommentHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateCommentCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\CommentWriteRepository;
+
+class UpdateCommentHandler
+{
+    /** @var CommentWriteRepository */
+    private $repository;
+
+    public function __construct(CommentWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(UpdateCommentCommand $command): int
+    {
+        $this->repository->update($command->getCommentId(), $command->getData());
+
+        return $command->getCommentId();
+    }
+}

--- a/src/Core/Domain/Blog/CommandHandler/UpdateTagHandler.php
+++ b/src/Core/Domain/Blog/CommandHandler/UpdateTagHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\CommandHandler;
+
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Command\UpdateTagCommand;
+use PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository\TagWriteRepository;
+
+class UpdateTagHandler
+{
+    /** @var TagWriteRepository */
+    private $repository;
+
+    public function __construct(TagWriteRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function __invoke(UpdateTagCommand $command): int
+    {
+        $this->repository->update($command->getTagId(), $command->getData());
+
+        return $command->getTagId();
+    }
+}

--- a/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Tools;
+
+class AuthorWriteRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function create(array $data): int
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->insert('ever_blog_author', [
+            'id_employee' => (int) $data['id_employee'],
+            'id_shop' => (int) $data['id_shop'],
+            'nickhandle' => (string) $data['nickhandle'],
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+            'allowed_groups' => null,
+            'count' => 0,
+        ]);
+
+        $authorId = (int) $connection->lastInsertId();
+        $this->replaceRelations($authorId, $data);
+
+        return $authorId;
+    }
+
+    public function update(int $authorId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->update('ever_blog_author', [
+            'id_employee' => (int) $data['id_employee'],
+            'nickhandle' => (string) $data['nickhandle'],
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+        ], ['id_ever_author' => $authorId]);
+
+        $this->replaceRelations($authorId, $data);
+    }
+
+    public function delete(int $authorId): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_author_lang', ['id_ever_author' => $authorId]);
+        $connection->delete('ever_blog_author_shop', ['id_ever_author' => $authorId]);
+        $connection->delete('ever_blog_author', ['id_ever_author' => $authorId]);
+    }
+
+    private function replaceRelations(int $authorId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_author_lang', ['id_ever_author' => $authorId]);
+        $connection->delete('ever_blog_author_shop', ['id_ever_author' => $authorId]);
+        $connection->insert('ever_blog_author_shop', ['id_ever_author' => $authorId, 'id_shop' => (int) $data['id_shop']]);
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+            $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $content = (string) ($data['bio_' . $langId] ?? $data['bio']);
+
+            $connection->insert('ever_blog_author_lang', [
+                'id_ever_author' => $authorId,
+                'id_lang' => $langId,
+                'meta_title' => $metaTitle,
+                'meta_description' => $metaDescription,
+                'link_rewrite' => Tools::str2url((string) ($data['nickhandle'] ?? 'author-' . $authorId)),
+                'content' => $content,
+                'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? ''),
+            ]);
+        }
+    }
+}

--- a/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Tools;
+
+class CategoryWriteRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function create(array $data): int
+    {
+        $connection = $this->entityManager->getConnection();
+        $now = date('Y-m-d H:i:s');
+        $connection->insert('ever_blog_category', [
+            'id_parent_category' => $data['id_parent_category'],
+            'id_shop' => (int) $data['id_shop'],
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+            'is_root_category' => (int) $data['is_root_category'],
+            'count' => 0,
+            'allowed_groups' => null,
+            'groups' => null,
+            'date_add' => $now,
+            'date_upd' => $now,
+        ]);
+
+        $categoryId = (int) $connection->lastInsertId();
+        $this->replaceRelations($categoryId, $data);
+
+        return $categoryId;
+    }
+
+    public function update(int $categoryId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->update('ever_blog_category', [
+            'id_parent_category' => $data['id_parent_category'],
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+            'date_upd' => date('Y-m-d H:i:s'),
+        ], ['id_ever_category' => $categoryId]);
+
+        $this->replaceRelations($categoryId, $data);
+    }
+
+    public function delete(int $categoryId): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_category_lang', ['id_ever_category' => $categoryId]);
+        $connection->delete('ever_blog_category_shop', ['id_ever_category' => $categoryId]);
+        $connection->delete('ever_blog_category', ['id_ever_category' => $categoryId]);
+    }
+
+    private function replaceRelations(int $categoryId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_category_lang', ['id_ever_category' => $categoryId]);
+        $connection->delete('ever_blog_category_shop', ['id_ever_category' => $categoryId]);
+        $connection->insert('ever_blog_category_shop', ['id_ever_category' => $categoryId, 'id_shop' => (int) $data['id_shop']]);
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $title = (string) ($data['title_' . $langId] ?? $data['title']);
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+            $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+
+            $connection->insert('ever_blog_category_lang', [
+                'id_ever_category' => $categoryId,
+                'id_lang' => $langId,
+                'title' => $title,
+                'meta_title' => $metaTitle,
+                'meta_description' => $metaDescription,
+                'link_rewrite' => Tools::str2url($title ?: $metaTitle),
+                'content' => (string) ($data['content_' . $langId] ?? $data['content']),
+                'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
+            ]);
+        }
+    }
+}

--- a/src/Core/Domain/Blog/Repository/CommentWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/CommentWriteRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+
+class CommentWriteRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function create(array $data): int
+    {
+        $connection = $this->entityManager->getConnection();
+        $now = date('Y-m-d H:i:s');
+
+        $connection->insert('ever_blog_comments', [
+            'id_ever_post' => (int) $data['id_ever_post'],
+            'id_lang' => (int) $data['id_lang'],
+            'comment' => (string) $data['comment'],
+            'name' => (string) $data['name'],
+            'user_email' => (string) $data['user_email'],
+            'active' => (int) $data['active'],
+            'date_add' => $now,
+            'date_upd' => $now,
+        ]);
+
+        return (int) $connection->lastInsertId();
+    }
+
+    public function update(int $commentId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->update('ever_blog_comments', [
+            'id_ever_post' => (int) $data['id_ever_post'],
+            'id_lang' => (int) $data['id_lang'],
+            'comment' => (string) $data['comment'],
+            'name' => (string) $data['name'],
+            'user_email' => (string) $data['user_email'],
+            'active' => (int) $data['active'],
+            'date_upd' => date('Y-m-d H:i:s'),
+        ], ['id_ever_comment' => $commentId]);
+    }
+
+    public function delete(int $commentId): void
+    {
+        $this->entityManager->getConnection()->delete('ever_blog_comments', ['id_ever_comment' => $commentId]);
+    }
+}

--- a/src/Core/Domain/Blog/Repository/TagWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/TagWriteRepository.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Core\Domain\Blog\Repository;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Tools;
+
+class TagWriteRepository
+{
+    /** @var EntityManagerInterface */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function create(array $data): int
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->insert('ever_blog_tag', [
+            'id_shop' => (int) $data['id_shop'],
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+            'allowed_groups' => null,
+            'count' => 0,
+        ]);
+
+        $tagId = (int) $connection->lastInsertId();
+        $this->replaceRelations($tagId, $data);
+
+        return $tagId;
+    }
+
+    public function update(int $tagId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->update('ever_blog_tag', [
+            'active' => (int) $data['active'],
+            'indexable' => (int) $data['indexable'],
+            'follow' => (int) $data['follow'],
+            'sitemap' => (int) $data['sitemap'],
+        ], ['id_ever_tag' => $tagId]);
+
+        $this->replaceRelations($tagId, $data);
+    }
+
+    public function delete(int $tagId): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_tag_lang', ['id_ever_tag' => $tagId]);
+        $connection->delete('ever_blog_tag_shop', ['id_ever_tag' => $tagId]);
+        $connection->delete('ever_blog_tag', ['id_ever_tag' => $tagId]);
+    }
+
+    private function replaceRelations(int $tagId, array $data): void
+    {
+        $connection = $this->entityManager->getConnection();
+        $connection->delete('ever_blog_tag_lang', ['id_ever_tag' => $tagId]);
+        $connection->delete('ever_blog_tag_shop', ['id_ever_tag' => $tagId]);
+        $connection->insert('ever_blog_tag_shop', ['id_ever_tag' => $tagId, 'id_shop' => (int) $data['id_shop']]);
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $title = (string) ($data['title_' . $langId] ?? $data['title']);
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+            $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+
+            $connection->insert('ever_blog_tag_lang', [
+                'id_ever_tag' => $tagId,
+                'id_lang' => $langId,
+                'title' => $title,
+                'meta_title' => $metaTitle,
+                'meta_description' => $metaDescription,
+                'link_rewrite' => Tools::str2url($title ?: $metaTitle),
+                'content' => (string) ($data['content_' . $langId] ?? $data['content']),
+                'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Exposer les opérations d'écriture (POST/PUT/DELETE) pour les ressources administratives `category`, `tag`, `author` et `comment`. 
- Uniformiser le flux d'édition/validation/sauvegarde avec le même pattern que `Post` (form handling + command bus). 
- Implémenter la couche application/domaine pour gérer les commandes d'écriture de ces ressources (assembleurs, validateurs, handlers, repositories). 

### Description

- Ajout des routes `POST/PUT/DELETE` et passage des pages de formulaire `new`/`edit` à `methods: [GET, POST]` dans `config/routes.yml` pour `category`, `tag`, `author` et `comment`. 
- Extension des contrôleurs admin `CategoryController`, `TagController`, `AuthorController`, `CommentController` avec `createAction`, `updateAction`, `deleteAction`, gestion CSRF, réponses JSON et la soumission de formulaire (même pattern que `PostController`). 
- Ajout de la couche application: `*CommandAssembler` et `*RequestValidator` pour chaque ressource, et de la couche domaine: `Create/Update/Delete*Command`, `*Handler` et `*WriteRepository` (implémentations d'inserts/updates/deletes et persistence des relations langue/shop pour taxonomies/auteurs). 
- Enregistrement des nouveaux services/handlers/repositories/validators/assemblers et extension du `InMemoryCommandBus` dans `config/services.yml` pour dispatcher les nouvelles commandes. 

### Testing

- Exécution de vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés et créés (controllers, assemblers, validators, commands, handlers, repositories) et validation que `php -l` n'a retourné aucune erreur. 
- Exécution d'un batch `php -l` sur les nouveaux patterns `src/Application/Blog/*RequestValidator.php` et `src/Core/Domain/Blog/Command*` / `CommandHandler*` qui a aussi passé sans erreurs. 
- Les changements ont été commités (branch/HEAD short: shown in repo) après les contrôles automatiques.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22bcb85448322b66d3031f084d9fa)