### PR TITLE
Expose multilingual SEO and content fields for Category/Tag/Author admin forms

### DIFF
--- a/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
@@ -70,14 +70,15 @@ class AuthorWriteRepository
             $langId = (int) $language['id_lang'];
             $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
             $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
-            $content = (string) ($data['bio_' . $langId] ?? $data['bio']);
+            $content = (string) ($data['content_' . $langId] ?? ($data['bio_' . $langId] ?? $data['bio']));
+            $slug = (string) ($data['link_rewrite_' . $langId] ?? '');
 
             $connection->insert('ever_blog_author_lang', [
                 'id_ever_author' => $authorId,
                 'id_lang' => $langId,
                 'meta_title' => $metaTitle,
                 'meta_description' => $metaDescription,
-                'link_rewrite' => Tools::str2url((string) ($data['nickhandle'] ?? 'author-' . $authorId)),
+                'link_rewrite' => Tools::str2url($slug ?: (string) ($data['nickhandle'] ?? 'author-' . $authorId)),
                 'content' => $content,
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? ''),
             ]);

--- a/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
@@ -75,6 +75,7 @@ class CategoryWriteRepository
             $title = (string) ($data['title_' . $langId] ?? $data['title']);
             $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
             $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $slug = (string) ($data['link_rewrite_' . $langId] ?? '');
 
             $connection->insert('ever_blog_category_lang', [
                 'id_ever_category' => $categoryId,
@@ -82,7 +83,7 @@ class CategoryWriteRepository
                 'title' => $title,
                 'meta_title' => $metaTitle,
                 'meta_description' => $metaDescription,
-                'link_rewrite' => Tools::str2url($title ?: $metaTitle),
+                'link_rewrite' => Tools::str2url($slug ?: ($title ?: $metaTitle)),
                 'content' => (string) ($data['content_' . $langId] ?? $data['content']),
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
             ]);

--- a/src/Core/Domain/Blog/Repository/TagWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/TagWriteRepository.php
@@ -67,6 +67,7 @@ class TagWriteRepository
             $title = (string) ($data['title_' . $langId] ?? $data['title']);
             $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
             $metaDescription = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $slug = (string) ($data['link_rewrite_' . $langId] ?? '');
 
             $connection->insert('ever_blog_tag_lang', [
                 'id_ever_tag' => $tagId,
@@ -74,7 +75,7 @@ class TagWriteRepository
                 'title' => $title,
                 'meta_title' => $metaTitle,
                 'meta_description' => $metaDescription,
-                'link_rewrite' => Tools::str2url($title ?: $metaTitle),
+                'link_rewrite' => Tools::str2url($slug ?: ($title ?: $metaTitle)),
                 'content' => (string) ($data['content_' . $langId] ?? $data['content']),
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
             ]);

--- a/src/Form/DataProvider/AuthorFormDataProvider.php
+++ b/src/Form/DataProvider/AuthorFormDataProvider.php
@@ -2,6 +2,8 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use Tools;
+
 final class AuthorFormDataProvider
 {
     /**
@@ -9,10 +11,30 @@ final class AuthorFormDataProvider
      */
     public function getData(?int $id = null): array
     {
-        return [
+        $data = [
             'id' => $id,
             'nickhandle' => '',
             'bio' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
         ];
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+            $content = (string) ($data['content_' . $langId] ?? ($data['bio_' . $langId] ?? $data['bio']));
+
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($data['nickhandle'] ?: $metaTitle));
+            $data['content_' . $langId] = $content;
+            $data['bio_' . $langId] = $content;
+            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+        }
+
+        return $data;
     }
 }

--- a/src/Form/DataProvider/CategoryFormDataProvider.php
+++ b/src/Form/DataProvider/CategoryFormDataProvider.php
@@ -2,6 +2,8 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use Tools;
+
 final class CategoryFormDataProvider
 {
     /**
@@ -9,10 +11,29 @@ final class CategoryFormDataProvider
      */
     public function getData(?int $id = null): array
     {
-        return [
+        $data = [
             'id' => $id,
             'title' => '',
             'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
         ];
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $title = (string) ($data['title_' . $langId] ?? $data['title']);
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+
+            $data['title_' . $langId] = $title;
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($title ?: $metaTitle));
+            $data['content_' . $langId] = (string) ($data['content_' . $langId] ?? $data['content']);
+            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+        }
+
+        return $data;
     }
 }

--- a/src/Form/DataProvider/TagFormDataProvider.php
+++ b/src/Form/DataProvider/TagFormDataProvider.php
@@ -2,6 +2,8 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use Tools;
+
 final class TagFormDataProvider
 {
     /**
@@ -9,10 +11,29 @@ final class TagFormDataProvider
      */
     public function getData(?int $id = null): array
     {
-        return [
+        $data = [
             'id' => $id,
             'title' => '',
             'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
         ];
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $title = (string) ($data['title_' . $langId] ?? $data['title']);
+            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
+
+            $data['title_' . $langId] = $title;
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($title ?: $metaTitle));
+            $data['content_' . $langId] = (string) ($data['content_' . $langId] ?? $data['content']);
+            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+        }
+
+        return $data;
     }
 }

--- a/src/Form/Type/Admin/AuthorType.php
+++ b/src/Form/Type/Admin/AuthorType.php
@@ -3,16 +3,62 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
 
 final class AuthorType extends AbstractType
 {
+    private const META_TITLE_MAX_LENGTH = 70;
+    private const META_DESCRIPTION_MAX_LENGTH = 160;
+    private const SLUG_MAX_LENGTH = 128;
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('nickhandle', TextType::class, ['required' => false, 'label' => 'Pseudo'])
-            ->add('bio', TextType::class, ['required' => false, 'label' => 'Bio'])
-        ;
+        $builder->add('nickhandle', TextType::class, [
+            'required' => false,
+            'label' => 'Pseudo',
+            'constraints' => [new Length(['max' => 255])],
+        ]);
+
+        foreach (\Language::getLanguages(false) as $lang) {
+            $idLang = (int) $lang['id_lang'];
+            $isoCode = strtoupper((string) ($lang['iso_code'] ?? ''));
+            $suffix = $isoCode ? sprintf(' (%s)', $isoCode) : sprintf(' (langue #%d)', $idLang);
+
+            $builder
+                ->add(sprintf('meta_title_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Meta title' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_TITLE_MAX_LENGTH])],
+                ])
+                ->add(sprintf('meta_description_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Meta description' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_DESCRIPTION_MAX_LENGTH])],
+                ])
+                ->add(sprintf('link_rewrite_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Slug' . $suffix,
+                    'constraints' => [
+                        new Length(['max' => self::SLUG_MAX_LENGTH]),
+                        new Regex([
+                            'pattern' => '/^[a-z0-9]+(?:-[a-z0-9]+)*$/i',
+                            'message' => 'Le slug doit contenir uniquement des lettres, chiffres et tirets.',
+                        ]),
+                    ],
+                ])
+                ->add(sprintf('content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu' . $suffix,
+                ])
+                ->add(sprintf('bottom_content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu bas de page' . $suffix,
+                ])
+            ;
+        }
     }
 }

--- a/src/Form/Type/Admin/CategoryType.php
+++ b/src/Form/Type/Admin/CategoryType.php
@@ -3,16 +3,61 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
 
 final class CategoryType extends AbstractType
 {
+    private const META_TITLE_MAX_LENGTH = 70;
+    private const META_DESCRIPTION_MAX_LENGTH = 160;
+    private const SLUG_MAX_LENGTH = 128;
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('title', TextType::class, ['required' => false, 'label' => 'Titre'])
-            ->add('meta_title', TextType::class, ['required' => false, 'label' => 'Meta title'])
-        ;
+        foreach (\Language::getLanguages(false) as $lang) {
+            $idLang = (int) $lang['id_lang'];
+            $isoCode = strtoupper((string) ($lang['iso_code'] ?? ''));
+            $suffix = $isoCode ? sprintf(' (%s)', $isoCode) : sprintf(' (langue #%d)', $idLang);
+
+            $builder
+                ->add(sprintf('title_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Titre' . $suffix,
+                    'constraints' => [new Length(['max' => 255])],
+                ])
+                ->add(sprintf('meta_title_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Meta title' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_TITLE_MAX_LENGTH])],
+                ])
+                ->add(sprintf('meta_description_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Meta description' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_DESCRIPTION_MAX_LENGTH])],
+                ])
+                ->add(sprintf('link_rewrite_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Slug' . $suffix,
+                    'constraints' => [
+                        new Length(['max' => self::SLUG_MAX_LENGTH]),
+                        new Regex([
+                            'pattern' => '/^[a-z0-9]+(?:-[a-z0-9]+)*$/i',
+                            'message' => 'Le slug doit contenir uniquement des lettres, chiffres et tirets.',
+                        ]),
+                    ],
+                ])
+                ->add(sprintf('content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu' . $suffix,
+                ])
+                ->add(sprintf('bottom_content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu bas de page' . $suffix,
+                ])
+            ;
+        }
     }
 }

--- a/src/Form/Type/Admin/TagType.php
+++ b/src/Form/Type/Admin/TagType.php
@@ -3,16 +3,61 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\Regex;
 
 final class TagType extends AbstractType
 {
+    private const META_TITLE_MAX_LENGTH = 70;
+    private const META_DESCRIPTION_MAX_LENGTH = 160;
+    private const SLUG_MAX_LENGTH = 128;
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder
-            ->add('title', TextType::class, ['required' => false, 'label' => 'Titre'])
-            ->add('meta_title', TextType::class, ['required' => false, 'label' => 'Meta title'])
-        ;
+        foreach (\Language::getLanguages(false) as $lang) {
+            $idLang = (int) $lang['id_lang'];
+            $isoCode = strtoupper((string) ($lang['iso_code'] ?? ''));
+            $suffix = $isoCode ? sprintf(' (%s)', $isoCode) : sprintf(' (langue #%d)', $idLang);
+
+            $builder
+                ->add(sprintf('title_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Titre' . $suffix,
+                    'constraints' => [new Length(['max' => 255])],
+                ])
+                ->add(sprintf('meta_title_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Meta title' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_TITLE_MAX_LENGTH])],
+                ])
+                ->add(sprintf('meta_description_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Meta description' . $suffix,
+                    'constraints' => [new Length(['max' => self::META_DESCRIPTION_MAX_LENGTH])],
+                ])
+                ->add(sprintf('link_rewrite_%d', $idLang), TextType::class, [
+                    'required' => false,
+                    'label' => 'Slug' . $suffix,
+                    'constraints' => [
+                        new Length(['max' => self::SLUG_MAX_LENGTH]),
+                        new Regex([
+                            'pattern' => '/^[a-z0-9]+(?:-[a-z0-9]+)*$/i',
+                            'message' => 'Le slug doit contenir uniquement des lettres, chiffres et tirets.',
+                        ]),
+                    ],
+                ])
+                ->add(sprintf('content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu' . $suffix,
+                ])
+                ->add(sprintf('bottom_content_%d', $idLang), TextareaType::class, [
+                    'required' => false,
+                    'label' => 'Contenu bas de page' . $suffix,
+                ])
+            ;
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Permettre la gestion SEO et de contenu par langue pour les entités de taxonomie et les auteurs (meta title, meta description, slug/link_rewrite, content, bottom_content). 
- Appliquer des contraintes SEO/cohérence (longueurs et format de slug) et fournir un fallback automatique du slug depuis le titre/nickhandle.

### Description
- `CategoryType`, `TagType`, `AuthorType` ont été enrichis pour exposer des champs par langue (`*_<idLang>`) pour `meta_title`, `meta_description`, `link_rewrite`, `content` et `bottom_content`, avec labels suffixés par ISO langue et contraintes (`meta_title` 70, `meta_description` 160, `link_rewrite` 128 + regex de slug).
- Les form data providers (`CategoryFormDataProvider`, `TagFormDataProvider`, `AuthorFormDataProvider`) initialisent les clés traduites par langue et génèrent un slug par défaut via `Tools::str2url()` à partir du titre / meta_title (ou `nickhandle` pour les auteurs) lorsque `link_rewrite_{lang}` n'est pas fourni.
- Les repositories d'écriture (`CategoryWriteRepository`, `TagWriteRepository`, `AuthorWriteRepository`) ont été modifiés pour persister les `link_rewrite_{lang}` fournis et, à défaut, utiliser le fallback existant (titre/meta/nickhandle) afin que le slug saisi dans le formulaire soit pris en compte.
- Pour les auteurs, le provider supporte désormais `content_{lang}` tout en conservant la compatibilité avec l'ancien `bio_{lang}` et expose `bottom_content`.

### Testing
- Exécution de vérification de syntaxe PHP sur les fichiers modifiés avec : `php -l src/Form/Type/Admin/CategoryType.php && php -l src/Form/Type/Admin/TagType.php && php -l src/Form/Type/Admin/AuthorType.php && php -l src/Form/DataProvider/CategoryFormDataProvider.php && php -l src/Form/DataProvider/TagFormDataProvider.php && php -l src/Form/DataProvider/AuthorFormDataProvider.php && php -l src/Core/Domain/Blog/Repository/CategoryWriteRepository.php && php -l src/Core/Domain/Blog/Repository/TagWriteRepository.php && php -l src/Core/Domain/Blog/Repository/AuthorWriteRepository.php`.
- Tous les contrôles de syntaxe exécutés ont réussi (aucune erreur de syntaxe détectée).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22eb1f5788322b250f04df90ae7cf)