### PR TITLE
Hydrate admin form data providers from repositories

### DIFF
--- a/src/Form/DataProvider/AuthorFormDataProvider.php
+++ b/src/Form/DataProvider/AuthorFormDataProvider.php
@@ -2,18 +2,111 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use PrestaShop\Module\Everpsblog\Repository\AuthorRepository;
 use Tools;
 
 final class AuthorFormDataProvider
 {
+    /** @var AuthorRepository */
+    private $authorRepository;
+
+    public function __construct(AuthorRepository $authorRepository)
+    {
+        $this->authorRepository = $authorRepository;
+    }
+
     /**
      * @return array<string, mixed>
      */
     public function getData(?int $id = null): array
     {
+        if (null === $id) {
+            return $this->getCreationData(null);
+        }
+
+        $entity = $this->authorRepository->find($id);
+        if (null === $entity) {
+            return $this->getCreationData($id);
+        }
+
+        $connection = $this->authorRepository->getEntityManager()->getConnection();
+        /** @var array<string, mixed>|false $author */
+        $author = $connection->fetchAssociative(
+            'SELECT * FROM ever_blog_author WHERE id_ever_author = :id',
+            ['id' => $id]
+        );
+
+        if (!$author) {
+            return $this->getCreationData($id);
+        }
+
         $data = [
             'id' => $id,
+            'id_employee' => (int) ($author['id_employee'] ?? 0),
+            'nickhandle' => (string) ($author['nickhandle'] ?? ''),
+            'active' => (bool) ($author['active'] ?? 0),
+            'indexable' => (bool) ($author['indexable'] ?? 0),
+            'follow' => (bool) ($author['follow'] ?? 0),
+            'sitemap' => (bool) ($author['sitemap'] ?? 0),
+            'bio' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
+        ];
+
+        $translations = $connection->fetchAllAssociative(
+            'SELECT id_lang, meta_title, meta_description, link_rewrite, content, bottom_content
+             FROM ever_blog_author_lang
+             WHERE id_ever_author = :id',
+            ['id' => $id]
+        );
+        /** @var array<int, array<string, mixed>> $translationsByLang */
+        $translationsByLang = [];
+        foreach ($translations as $translation) {
+            $translationsByLang[(int) $translation['id_lang']] = $translation;
+        }
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $translation = $translationsByLang[$langId] ?? [];
+            $metaTitle = (string) ($translation['meta_title'] ?? $data['meta_title']);
+            $content = (string) ($translation['content'] ?? $data['bio']);
+
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($translation['meta_description'] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($translation['link_rewrite'] ?? Tools::str2url($data['nickhandle'] ?: $metaTitle));
+            $data['content_' . $langId] = $content;
+            $data['bio_' . $langId] = $content;
+            $data['bottom_content_' . $langId] = (string) ($translation['bottom_content'] ?? $data['bottom_content']);
+
+            if ('' === $data['meta_title'] && '' === $data['bio']) {
+                $data['meta_title'] = $metaTitle;
+                $data['meta_description'] = (string) $data['meta_description_' . $langId];
+                $data['link_rewrite'] = (string) $data['link_rewrite_' . $langId];
+                $data['content'] = $content;
+                $data['bio'] = $content;
+                $data['bottom_content'] = (string) $data['bottom_content_' . $langId];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCreationData(?int $id): array
+    {
+        $data = [
+            'id' => $id,
+            'id_employee' => 0,
             'nickhandle' => '',
+            'active' => true,
+            'indexable' => true,
+            'follow' => true,
+            'sitemap' => true,
             'bio' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -24,15 +117,12 @@ final class AuthorFormDataProvider
 
         foreach (\Language::getLanguages(false) as $language) {
             $langId = (int) $language['id_lang'];
-            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
-            $content = (string) ($data['content_' . $langId] ?? ($data['bio_' . $langId] ?? $data['bio']));
-
-            $data['meta_title_' . $langId] = $metaTitle;
-            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
-            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($data['nickhandle'] ?: $metaTitle));
-            $data['content_' . $langId] = $content;
-            $data['bio_' . $langId] = $content;
-            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+            $data['meta_title_' . $langId] = '';
+            $data['meta_description_' . $langId] = '';
+            $data['link_rewrite_' . $langId] = '';
+            $data['content_' . $langId] = '';
+            $data['bio_' . $langId] = '';
+            $data['bottom_content_' . $langId] = '';
         }
 
         return $data;

--- a/src/Form/DataProvider/CategoryFormDataProvider.php
+++ b/src/Form/DataProvider/CategoryFormDataProvider.php
@@ -2,17 +2,111 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use PrestaShop\Module\Everpsblog\Repository\CategoryRepository;
 use Tools;
 
 final class CategoryFormDataProvider
 {
+    /** @var CategoryRepository */
+    private $categoryRepository;
+
+    public function __construct(CategoryRepository $categoryRepository)
+    {
+        $this->categoryRepository = $categoryRepository;
+    }
+
     /**
      * @return array<string, mixed>
      */
     public function getData(?int $id = null): array
     {
+        if (null === $id) {
+            return $this->getCreationData(null);
+        }
+
+        $entity = $this->categoryRepository->find($id);
+        if (null === $entity) {
+            return $this->getCreationData($id);
+        }
+
+        $connection = $this->categoryRepository->getEntityManager()->getConnection();
+        /** @var array<string, mixed>|false $category */
+        $category = $connection->fetchAssociative(
+            'SELECT * FROM ever_blog_category WHERE id_ever_category = :id',
+            ['id' => $id]
+        );
+
+        if (!$category) {
+            return $this->getCreationData($id);
+        }
+
         $data = [
             'id' => $id,
+            'id_parent_category' => isset($category['id_parent_category']) ? (int) $category['id_parent_category'] : null,
+            'active' => (bool) ($category['active'] ?? 0),
+            'indexable' => (bool) ($category['indexable'] ?? 0),
+            'follow' => (bool) ($category['follow'] ?? 0),
+            'sitemap' => (bool) ($category['sitemap'] ?? 0),
+            'is_root_category' => (bool) ($category['is_root_category'] ?? 0),
+            'title' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
+        ];
+
+        $translations = $connection->fetchAllAssociative(
+            'SELECT id_lang, title, meta_title, meta_description, link_rewrite, content, bottom_content
+             FROM ever_blog_category_lang
+             WHERE id_ever_category = :id',
+            ['id' => $id]
+        );
+        /** @var array<int, array<string, mixed>> $translationsByLang */
+        $translationsByLang = [];
+        foreach ($translations as $translation) {
+            $translationsByLang[(int) $translation['id_lang']] = $translation;
+        }
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $translation = $translationsByLang[$langId] ?? [];
+            $title = (string) ($translation['title'] ?? $data['title']);
+            $metaTitle = (string) ($translation['meta_title'] ?? $data['meta_title']);
+
+            $data['title_' . $langId] = $title;
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($translation['meta_description'] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($translation['link_rewrite'] ?? Tools::str2url($title ?: $metaTitle));
+            $data['content_' . $langId] = (string) ($translation['content'] ?? $data['content']);
+            $data['bottom_content_' . $langId] = (string) ($translation['bottom_content'] ?? $data['bottom_content']);
+
+            if ('' === $data['title']) {
+                $data['title'] = $title;
+                $data['meta_title'] = $metaTitle;
+                $data['meta_description'] = (string) $data['meta_description_' . $langId];
+                $data['link_rewrite'] = (string) $data['link_rewrite_' . $langId];
+                $data['content'] = (string) $data['content_' . $langId];
+                $data['bottom_content'] = (string) $data['bottom_content_' . $langId];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCreationData(?int $id): array
+    {
+        $data = [
+            'id' => $id,
+            'id_parent_category' => null,
+            'active' => true,
+            'indexable' => true,
+            'follow' => true,
+            'sitemap' => true,
+            'is_root_category' => false,
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -23,15 +117,12 @@ final class CategoryFormDataProvider
 
         foreach (\Language::getLanguages(false) as $language) {
             $langId = (int) $language['id_lang'];
-            $title = (string) ($data['title_' . $langId] ?? $data['title']);
-            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
-
-            $data['title_' . $langId] = $title;
-            $data['meta_title_' . $langId] = $metaTitle;
-            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
-            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($title ?: $metaTitle));
-            $data['content_' . $langId] = (string) ($data['content_' . $langId] ?? $data['content']);
-            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+            $data['title_' . $langId] = '';
+            $data['meta_title_' . $langId] = '';
+            $data['meta_description_' . $langId] = '';
+            $data['link_rewrite_' . $langId] = '';
+            $data['content_' . $langId] = '';
+            $data['bottom_content_' . $langId] = '';
         }
 
         return $data;

--- a/src/Form/DataProvider/CommentFormDataProvider.php
+++ b/src/Form/DataProvider/CommentFormDataProvider.php
@@ -2,15 +2,69 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use PrestaShop\Module\Everpsblog\Repository\CommentRepository;
+
 final class CommentFormDataProvider
 {
+    /** @var CommentRepository */
+    private $commentRepository;
+
+    public function __construct(CommentRepository $commentRepository)
+    {
+        $this->commentRepository = $commentRepository;
+    }
+
     /**
      * @return array<string, mixed>
      */
     public function getData(?int $id = null): array
     {
+        if (null === $id) {
+            return $this->getCreationData(null);
+        }
+
+        $entity = $this->commentRepository->find($id);
+        if (null === $entity) {
+            return $this->getCreationData($id);
+        }
+
+        $connection = $this->commentRepository->getEntityManager()->getConnection();
+        /** @var array<string, mixed>|false $comment */
+        $comment = $connection->fetchAssociative(
+            'SELECT * FROM ever_blog_comments WHERE id_ever_comment = :id',
+            ['id' => $id]
+        );
+
+        if (!$comment) {
+            return $this->getCreationData($id);
+        }
+
         return [
             'id' => $id,
+            'id_ever_post' => (int) ($comment['id_ever_post'] ?? 0),
+            'id_lang' => (int) ($comment['id_lang'] ?? 0),
+            'name' => (string) ($comment['name'] ?? ''),
+            'comment' => (string) ($comment['comment'] ?? ''),
+            'user_email' => (string) ($comment['user_email'] ?? ''),
+            'active' => (bool) ($comment['active'] ?? 0),
+            'nickname' => (string) ($comment['name'] ?? ''),
+            'content' => (string) ($comment['comment'] ?? ''),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCreationData(?int $id): array
+    {
+        return [
+            'id' => $id,
+            'id_ever_post' => 0,
+            'id_lang' => 0,
+            'name' => '',
+            'comment' => '',
+            'user_email' => '',
+            'active' => true,
             'nickname' => '',
             'content' => '',
         ];

--- a/src/Form/DataProvider/PostFormDataProvider.php
+++ b/src/Form/DataProvider/PostFormDataProvider.php
@@ -2,17 +2,183 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use PrestaShop\Module\Everpsblog\Repository\PostRepository;
+use Tools;
+
 final class PostFormDataProvider
 {
+    /** @var PostRepository */
+    private $postRepository;
+
+    public function __construct(PostRepository $postRepository)
+    {
+        $this->postRepository = $postRepository;
+    }
+
     /**
      * @return array<string, mixed>
      */
     public function getData(?int $id = null): array
     {
-        return [
+        if (null === $id) {
+            return $this->getCreationData(null);
+        }
+
+        $entity = $this->postRepository->find($id);
+        if (null === $entity) {
+            return $this->getCreationData($id);
+        }
+
+        $connection = $this->postRepository->getEntityManager()->getConnection();
+        /** @var array<string, mixed>|false $post */
+        $post = $connection->fetchAssociative(
+            'SELECT * FROM ever_blog_post WHERE id_ever_post = :id',
+            ['id' => $id]
+        );
+
+        if (!$post) {
+            return $this->getCreationData($id);
+        }
+
+        $data = [
             'id' => $id,
+            'post_status' => (string) ($post['post_status'] ?? 'draft'),
+            'date_add' => isset($post['date_add']) ? (string) $post['date_add'] : '',
+            'id_author' => (int) ($post['id_author'] ?? 0),
+            'id_default_category' => (int) ($post['id_default_category'] ?? 0),
+            'indexable' => (bool) ($post['indexable'] ?? 0),
+            'follow' => (bool) ($post['follow'] ?? 0),
+            'sitemap' => (bool) ($post['sitemap'] ?? 0),
+            'starred' => (bool) ($post['starred'] ?? 0),
+            'psswd' => '',
+            'post_categories' => [],
+            'post_tags' => [],
+            'post_products' => [],
+            'allowed_groups' => $this->normalizeIntCollection($post['allowed_groups'] ?? null),
             'title' => '',
+            'content' => '',
             'excerpt' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
         ];
+
+        $data['post_categories'] = array_values(array_map('intval', array_column($connection->fetchAllAssociative(
+            'SELECT id_ever_post_category FROM ever_blog_post_category WHERE id_ever_post = :id',
+            ['id' => $id]
+        ), 'id_ever_post_category')));
+        $data['post_tags'] = array_values(array_map('intval', array_column($connection->fetchAllAssociative(
+            'SELECT id_ever_post_tag FROM ever_blog_post_tag WHERE id_ever_post = :id',
+            ['id' => $id]
+        ), 'id_ever_post_tag')));
+        $data['post_products'] = array_values(array_map('intval', array_column($connection->fetchAllAssociative(
+            'SELECT id_ever_post_product FROM ever_blog_post_product WHERE id_ever_post = :id',
+            ['id' => $id]
+        ), 'id_ever_post_product')));
+
+        $translations = $connection->fetchAllAssociative(
+            'SELECT id_lang, title, content, excerpt, meta_title, meta_description, link_rewrite
+             FROM ever_blog_post_lang
+             WHERE id_ever_post = :id',
+            ['id' => $id]
+        );
+        /** @var array<int, array<string, mixed>> $translationsByLang */
+        $translationsByLang = [];
+        foreach ($translations as $translation) {
+            $translationsByLang[(int) $translation['id_lang']] = $translation;
+        }
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $translation = $translationsByLang[$langId] ?? [];
+            $title = (string) ($translation['title'] ?? $data['title']);
+            $metaTitle = (string) ($translation['meta_title'] ?? $data['meta_title']);
+
+            $data['title_' . $langId] = $title;
+            $data['content_' . $langId] = (string) ($translation['content'] ?? $data['content']);
+            $data['excerpt_' . $langId] = (string) ($translation['excerpt'] ?? $data['excerpt']);
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($translation['meta_description'] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($translation['link_rewrite'] ?? Tools::str2url($title ?: $metaTitle));
+
+            if ('' === $data['title']) {
+                $data['title'] = $title;
+                $data['content'] = (string) $data['content_' . $langId];
+                $data['excerpt'] = (string) $data['excerpt_' . $langId];
+                $data['meta_title'] = $metaTitle;
+                $data['meta_description'] = (string) $data['meta_description_' . $langId];
+                $data['link_rewrite'] = (string) $data['link_rewrite_' . $langId];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCreationData(?int $id): array
+    {
+        $data = [
+            'id' => $id,
+            'post_status' => 'draft',
+            'date_add' => date('Y-m-d H:i:s'),
+            'id_author' => 0,
+            'id_default_category' => 0,
+            'indexable' => true,
+            'follow' => true,
+            'sitemap' => true,
+            'starred' => false,
+            'psswd' => '',
+            'post_categories' => [],
+            'post_tags' => [],
+            'post_products' => [],
+            'allowed_groups' => [],
+            'title' => '',
+            'content' => '',
+            'excerpt' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+        ];
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $data['title_' . $langId] = '';
+            $data['content_' . $langId] = '';
+            $data['excerpt_' . $langId] = '';
+            $data['meta_title_' . $langId] = '';
+            $data['meta_description_' . $langId] = '';
+            $data['link_rewrite_' . $langId] = '';
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int[]
+     */
+    private function normalizeIntCollection($value): array
+    {
+        if (null === $value || '' === $value) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            return array_values(array_map('intval', $value));
+        }
+
+        $decoded = json_decode((string) $value, true);
+        if (is_array($decoded)) {
+            return array_values(array_map('intval', $decoded));
+        }
+
+        $items = array_filter(array_map('trim', explode(',', (string) $value)), static function ($item) {
+            return '' !== $item;
+        });
+
+        return array_values(array_map('intval', $items));
     }
 }

--- a/src/Form/DataProvider/TagFormDataProvider.php
+++ b/src/Form/DataProvider/TagFormDataProvider.php
@@ -2,17 +2,106 @@
 
 namespace PrestaShop\Module\Everpsblog\Form\DataProvider;
 
+use PrestaShop\Module\Everpsblog\Repository\TagRepository;
 use Tools;
 
 final class TagFormDataProvider
 {
+    /** @var TagRepository */
+    private $tagRepository;
+
+    public function __construct(TagRepository $tagRepository)
+    {
+        $this->tagRepository = $tagRepository;
+    }
+
     /**
      * @return array<string, mixed>
      */
     public function getData(?int $id = null): array
     {
+        if (null === $id) {
+            return $this->getCreationData(null);
+        }
+
+        $entity = $this->tagRepository->find($id);
+        if (null === $entity) {
+            return $this->getCreationData($id);
+        }
+
+        $connection = $this->tagRepository->getEntityManager()->getConnection();
+        /** @var array<string, mixed>|false $tag */
+        $tag = $connection->fetchAssociative(
+            'SELECT * FROM ever_blog_tag WHERE id_ever_tag = :id',
+            ['id' => $id]
+        );
+        if (!$tag) {
+            return $this->getCreationData($id);
+        }
+
         $data = [
             'id' => $id,
+            'active' => (bool) ($tag['active'] ?? 0),
+            'indexable' => (bool) ($tag['indexable'] ?? 0),
+            'follow' => (bool) ($tag['follow'] ?? 0),
+            'sitemap' => (bool) ($tag['sitemap'] ?? 0),
+            'title' => '',
+            'meta_title' => '',
+            'meta_description' => '',
+            'link_rewrite' => '',
+            'content' => '',
+            'bottom_content' => '',
+        ];
+
+        $translations = $connection->fetchAllAssociative(
+            'SELECT id_lang, title, meta_title, meta_description, link_rewrite, content, bottom_content
+             FROM ever_blog_tag_lang
+             WHERE id_ever_tag = :id',
+            ['id' => $id]
+        );
+        /** @var array<int, array<string, mixed>> $translationsByLang */
+        $translationsByLang = [];
+        foreach ($translations as $translation) {
+            $translationsByLang[(int) $translation['id_lang']] = $translation;
+        }
+
+        foreach (\Language::getLanguages(false) as $language) {
+            $langId = (int) $language['id_lang'];
+            $translation = $translationsByLang[$langId] ?? [];
+            $title = (string) ($translation['title'] ?? $data['title']);
+            $metaTitle = (string) ($translation['meta_title'] ?? $data['meta_title']);
+
+            $data['title_' . $langId] = $title;
+            $data['meta_title_' . $langId] = $metaTitle;
+            $data['meta_description_' . $langId] = (string) ($translation['meta_description'] ?? $data['meta_description']);
+            $data['link_rewrite_' . $langId] = (string) ($translation['link_rewrite'] ?? Tools::str2url($title ?: $metaTitle));
+            $data['content_' . $langId] = (string) ($translation['content'] ?? $data['content']);
+            $data['bottom_content_' . $langId] = (string) ($translation['bottom_content'] ?? $data['bottom_content']);
+
+            if ('' === $data['title']) {
+                $data['title'] = $title;
+                $data['meta_title'] = $metaTitle;
+                $data['meta_description'] = (string) $data['meta_description_' . $langId];
+                $data['link_rewrite'] = (string) $data['link_rewrite_' . $langId];
+                $data['content'] = (string) $data['content_' . $langId];
+                $data['bottom_content'] = (string) $data['bottom_content_' . $langId];
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCreationData(?int $id): array
+    {
+        $data = [
+            'id' => $id,
+            'active' => true,
+            'indexable' => true,
+            'follow' => true,
+            'sitemap' => true,
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -23,15 +112,12 @@ final class TagFormDataProvider
 
         foreach (\Language::getLanguages(false) as $language) {
             $langId = (int) $language['id_lang'];
-            $title = (string) ($data['title_' . $langId] ?? $data['title']);
-            $metaTitle = (string) ($data['meta_title_' . $langId] ?? $data['meta_title']);
-
-            $data['title_' . $langId] = $title;
-            $data['meta_title_' . $langId] = $metaTitle;
-            $data['meta_description_' . $langId] = (string) ($data['meta_description_' . $langId] ?? $data['meta_description']);
-            $data['link_rewrite_' . $langId] = (string) ($data['link_rewrite_' . $langId] ?? Tools::str2url($title ?: $metaTitle));
-            $data['content_' . $langId] = (string) ($data['content_' . $langId] ?? $data['content']);
-            $data['bottom_content_' . $langId] = (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']);
+            $data['title_' . $langId] = '';
+            $data['meta_title_' . $langId] = '';
+            $data['meta_description_' . $langId] = '';
+            $data['link_rewrite_' . $langId] = '';
+            $data['content_' . $langId] = '';
+            $data['bottom_content_' . $langId] = '';
         }
 
         return $data;


### PR DESCRIPTION
### Motivation
- Ensure admin forms are pre-filled with persisted data when editing entities instead of returning empty defaults. 
- Normalize provider output to match existing `FormType` expectations (including per-language suffixed keys) so assemblers/validators receive consistent payloads. 
- Keep explicit defaults only for creation mode to avoid unintentionally overriding stored values.

### Description
- Inject repository dependencies into `PostFormDataProvider`, `CategoryFormDataProvider`, `TagFormDataProvider`, `AuthorFormDataProvider` and `CommentFormDataProvider` and branch `getData()` into creation vs edition paths. 
- When an `id` is provided, load scalar fields and relations from the DB (posts: `post_status`, `date_add`, `id_author`, `id_default_category`, `post_categories`, `post_tags`, `post_products`, `allowed_groups`; comments: `id_ever_post`, `id_lang`, `name`, `comment`, `user_email`, `active`), and hydrate translations into per-language keys like `title_<langId>`, `meta_title_<langId>`, `content_<langId>`, etc. 
- Normalize relation/collection values to arrays of ints via `normalizeIntCollection()` (posts) and ensure non-suffixed fallbacks (`title`, `meta_title`, `content`, `link_rewrite`, ...) are filled from the first available translation to keep compatibility with existing assemblers. 
- Provide `getCreationData()` helper methods to expose explicit defaults used only in create mode and avoid leaking defaults during edits.

### Testing
- Ran syntax checks: `php -l` on `src/Form/DataProvider/PostFormDataProvider.php`, `CategoryFormDataProvider.php`, `TagFormDataProvider.php`, `AuthorFormDataProvider.php` and `CommentFormDataProvider.php`, and all files reported "No syntax errors detected."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e230a224d08322b3b13df3562d9724)