### PR TITLE
Add structured validation rules for blog request assemblers

### DIFF
--- a/src/Application/Blog/AbstractRequestValidator.php
+++ b/src/Application/Blog/AbstractRequestValidator.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PrestaShop\Module\Everpsblog\Adapter\LegacyLanguageAdapter;
+use Throwable;
+use Tools;
+
+abstract class AbstractRequestValidator
+{
+    private const META_TITLE_MAX_LENGTH = 70;
+    private const META_DESCRIPTION_MAX_LENGTH = 160;
+    private const SLUG_MAX_LENGTH = 128;
+
+    /** @var EntityManagerInterface */
+    protected $entityManager;
+
+    /** @var LegacyLanguageAdapter */
+    protected $languageAdapter;
+
+    /** @var array<string, string[]> */
+    private $fieldErrors = [];
+
+    /** @var string[] */
+    private $globalErrors = [];
+
+    public function __construct(EntityManagerInterface $entityManager, LegacyLanguageAdapter $languageAdapter)
+    {
+        $this->entityManager = $entityManager;
+        $this->languageAdapter = $languageAdapter;
+    }
+
+    protected function resetErrors(): void
+    {
+        $this->fieldErrors = [];
+        $this->globalErrors = [];
+    }
+
+    protected function addFieldError(string $field, string $message): void
+    {
+        if (!isset($this->fieldErrors[$field])) {
+            $this->fieldErrors[$field] = [];
+        }
+
+        $this->fieldErrors[$field][] = $message;
+    }
+
+    protected function addGlobalError(string $message): void
+    {
+        $this->globalErrors[] = $message;
+    }
+
+    protected function throwIfInvalid(): void
+    {
+        if (!empty($this->fieldErrors) || !empty($this->globalErrors)) {
+            throw new RequestValidationException($this->fieldErrors, $this->globalErrors);
+        }
+    }
+
+    /**
+     * @return int[]
+     */
+    protected function getLanguageIds(): array
+    {
+        return array_map(static function (array $language): int {
+            return (int) ($language['id_lang'] ?? 0);
+        }, $this->languageAdapter->getLanguages(false));
+    }
+
+    protected function getDefaultLanguageId(): int
+    {
+        return $this->languageAdapter->getDefaultLanguageId();
+    }
+
+    protected function ensureDefaultTitle(array $requestData, string $fieldPrefix = 'title_'): void
+    {
+        $defaultLangField = $fieldPrefix . $this->getDefaultLanguageId();
+        $title = trim((string) ($requestData[$defaultLangField] ?? ''));
+        if ('' === $title) {
+            $this->addFieldError($defaultLangField, 'Ce champ est obligatoire (langue par défaut).');
+        }
+    }
+
+    protected function normalizeSeoFields(array $requestData, string $titleFallbackPrefix = 'title_'): array
+    {
+        foreach ($this->getLanguageIds() as $langId) {
+            $metaTitleField = 'meta_title_' . $langId;
+            $metaDescriptionField = 'meta_description_' . $langId;
+            $slugField = 'link_rewrite_' . $langId;
+
+            $metaTitle = trim((string) ($requestData[$metaTitleField] ?? ''));
+            $metaDescription = trim((string) ($requestData[$metaDescriptionField] ?? ''));
+            $slug = trim((string) ($requestData[$slugField] ?? ''));
+            $title = trim((string) ($requestData[$titleFallbackPrefix . $langId] ?? ''));
+
+            if (Tools::strlen($metaTitle) > self::META_TITLE_MAX_LENGTH) {
+                $this->addFieldError($metaTitleField, sprintf('Maximum %d caractères.', self::META_TITLE_MAX_LENGTH));
+            }
+
+            if (Tools::strlen($metaDescription) > self::META_DESCRIPTION_MAX_LENGTH) {
+                $this->addFieldError($metaDescriptionField, sprintf('Maximum %d caractères.', self::META_DESCRIPTION_MAX_LENGTH));
+            }
+
+            $normalizedSlug = Tools::str2url($slug ?: ($title ?: $metaTitle));
+            if ('' !== $normalizedSlug && Tools::strlen($normalizedSlug) > self::SLUG_MAX_LENGTH) {
+                $this->addFieldError($slugField, sprintf('Slug trop long (maximum %d caractères).', self::SLUG_MAX_LENGTH));
+                continue;
+            }
+
+            $requestData[$slugField] = $normalizedSlug;
+        }
+
+        return $requestData;
+    }
+
+    protected function normalizePostStatusAndDate(array $requestData): array
+    {
+        $statusField = 'post_status';
+        $dateField = 'date_add';
+
+        $status = trim((string) ($requestData[$statusField] ?? 'draft'));
+        if ('' === $status) {
+            $status = 'draft';
+        }
+
+        $dateValue = (string) ($requestData[$dateField] ?? '');
+        if ('' === trim($dateValue)) {
+            $requestData[$statusField] = $status;
+
+            return $requestData;
+        }
+
+        $publicationDate = $this->parseDate($dateValue);
+        if (null === $publicationDate) {
+            $this->addFieldError($dateField, 'Format de date invalide.');
+
+            return $requestData;
+        }
+
+        $now = new DateTimeImmutable('now');
+        if ($publicationDate > $now && 'published' === $status) {
+            $requestData[$statusField] = 'planned';
+            $this->addGlobalError('Le statut a été ajusté à "planned" car la date de publication est dans le futur.');
+        } elseif ($publicationDate <= $now && 'planned' === $status) {
+            $requestData[$statusField] = 'published';
+            $this->addGlobalError('Le statut a été ajusté à "published" car la date de publication est passée.');
+        } else {
+            $requestData[$statusField] = $status;
+        }
+
+        return $requestData;
+    }
+
+    protected function existsInModuleTable(string $table, string $idColumn, int $id): bool
+    {
+        if ($id <= 0) {
+            return false;
+        }
+
+        /** @var Connection $connection */
+        $connection = $this->entityManager->getConnection();
+        $sql = sprintf('SELECT 1 FROM %s WHERE %s = :id LIMIT 1', $table, $idColumn);
+
+        return false !== $connection->fetchOne($sql, ['id' => $id]);
+    }
+
+    protected function existsInPrestashopTable(string $table, string $idColumn, int $id): bool
+    {
+        if ($id <= 0) {
+            return false;
+        }
+
+        /** @var Connection $connection */
+        $connection = $this->entityManager->getConnection();
+        $sql = sprintf('SELECT 1 FROM %s%s WHERE %s = :id LIMIT 1', _DB_PREFIX_, $table, $idColumn);
+
+        return false !== $connection->fetchOne($sql, ['id' => $id]);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int[]
+     */
+    protected function normalizeIntCollection($value): array
+    {
+        if (is_array($value)) {
+            $values = $value;
+        } elseif (null === $value || '' === $value) {
+            $values = [];
+        } else {
+            $values = [$value];
+        }
+
+        $normalized = array_values(array_filter(array_map(static function ($item): int {
+            return (int) $item;
+        }, $values), static function (int $item): bool {
+            return $item > 0;
+        }));
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function parseDate(string $date): ?DateTimeImmutable
+    {
+        $parsed = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $date);
+        if (false !== $parsed) {
+            return $parsed;
+        }
+
+        try {
+            return new DateTimeImmutable($date);
+        } catch (Throwable $exception) {
+            return null;
+        }
+    }
+}

--- a/src/Application/Blog/AuthorRequestValidator.php
+++ b/src/Application/Blog/AuthorRequestValidator.php
@@ -2,10 +2,26 @@
 
 namespace PrestaShop\Module\Everpsblog\Application\Blog;
 
-class AuthorRequestValidator
+class AuthorRequestValidator extends AbstractRequestValidator
 {
     public function validate(array $requestData): array
     {
+        $this->resetErrors();
+
+        $nickhandle = trim((string) ($requestData['nickhandle'] ?? ''));
+        if ('' === $nickhandle) {
+            $this->addFieldError('nickhandle', 'Le pseudo est obligatoire.');
+        }
+
+        $requestData = $this->normalizeSeoFields($requestData, 'meta_title_');
+
+        $employeeId = (int) ($requestData['id_employee'] ?? 0);
+        if ($employeeId > 0 && !$this->existsInPrestashopTable('employee', 'id_employee', $employeeId)) {
+            $this->addFieldError('id_employee', sprintf('Employé introuvable (id: %d).', $employeeId));
+        }
+
+        $this->throwIfInvalid();
+
         return $requestData;
     }
 }

--- a/src/Application/Blog/CategoryRequestValidator.php
+++ b/src/Application/Blog/CategoryRequestValidator.php
@@ -2,10 +2,22 @@
 
 namespace PrestaShop\Module\Everpsblog\Application\Blog;
 
-class CategoryRequestValidator
+class CategoryRequestValidator extends AbstractRequestValidator
 {
     public function validate(array $requestData): array
     {
+        $this->resetErrors();
+
+        $this->ensureDefaultTitle($requestData);
+        $requestData = $this->normalizeSeoFields($requestData);
+
+        $parentCategoryId = (int) ($requestData['id_parent_category'] ?? 0);
+        if ($parentCategoryId > 0 && !$this->existsInModuleTable('ever_blog_category', 'id_ever_category', $parentCategoryId)) {
+            $this->addFieldError('id_parent_category', sprintf('Catégorie parente introuvable (id: %d).', $parentCategoryId));
+        }
+
+        $this->throwIfInvalid();
+
         return $requestData;
     }
 }

--- a/src/Application/Blog/CommentRequestValidator.php
+++ b/src/Application/Blog/CommentRequestValidator.php
@@ -2,15 +2,33 @@
 
 namespace PrestaShop\Module\Everpsblog\Application\Blog;
 
-use InvalidArgumentException;
-
-class CommentRequestValidator
+class CommentRequestValidator extends AbstractRequestValidator
 {
     public function validate(array $requestData): array
     {
-        if (empty($requestData['id_ever_post'])) {
-            throw new InvalidArgumentException('id_ever_post is required for comment commands.');
+        $this->resetErrors();
+
+        $postId = (int) ($requestData['id_ever_post'] ?? 0);
+        if ($postId <= 0) {
+            $this->addFieldError('id_ever_post', 'Ce champ est obligatoire.');
+        } elseif (!$this->existsInModuleTable('ever_blog_post', 'id_ever_post', $postId)) {
+            $this->addFieldError('id_ever_post', sprintf('Article introuvable (id: %d).', $postId));
         }
+
+        $nickname = trim((string) ($requestData['nickname'] ?? $requestData['name'] ?? ''));
+        if ('' === $nickname) {
+            $this->addFieldError('nickname', 'Le nom est obligatoire.');
+        }
+
+        $content = trim((string) ($requestData['content'] ?? $requestData['comment'] ?? ''));
+        if ('' === $content) {
+            $this->addFieldError('content', 'Le commentaire est obligatoire.');
+        }
+
+        $requestData['name'] = $nickname;
+        $requestData['comment'] = $content;
+
+        $this->throwIfInvalid();
 
         return $requestData;
     }

--- a/src/Application/Blog/PostRequestValidator.php
+++ b/src/Application/Blog/PostRequestValidator.php
@@ -2,10 +2,52 @@
 
 namespace PrestaShop\Module\Everpsblog\Application\Blog;
 
-class PostRequestValidator
+class PostRequestValidator extends AbstractRequestValidator
 {
     public function validate(array $requestData): array
     {
+        $this->resetErrors();
+
+        $this->ensureDefaultTitle($requestData);
+        $requestData = $this->normalizeSeoFields($requestData);
+        $requestData = $this->normalizePostStatusAndDate($requestData);
+
+        $authorId = (int) ($requestData['id_author'] ?? 0);
+        if ($authorId > 0 && !$this->existsInModuleTable('ever_blog_author', 'id_ever_author', $authorId)) {
+            $this->addFieldError('id_author', sprintf('Auteur introuvable (id: %d).', $authorId));
+        }
+
+        $defaultCategoryId = (int) ($requestData['id_default_category'] ?? 0);
+        if ($defaultCategoryId > 0 && !$this->existsInModuleTable('ever_blog_category', 'id_ever_category', $defaultCategoryId)) {
+            $this->addFieldError('id_default_category', sprintf('Catégorie introuvable (id: %d).', $defaultCategoryId));
+        }
+
+        $postCategories = $this->normalizeIntCollection($requestData['post_categories'] ?? []);
+        foreach ($postCategories as $categoryId) {
+            if (!$this->existsInModuleTable('ever_blog_category', 'id_ever_category', $categoryId)) {
+                $this->addFieldError('post_categories', sprintf('Catégorie introuvable (id: %d).', $categoryId));
+            }
+        }
+        $requestData['post_categories'] = $postCategories;
+
+        $postTags = $this->normalizeIntCollection($requestData['post_tags'] ?? []);
+        foreach ($postTags as $tagId) {
+            if (!$this->existsInModuleTable('ever_blog_tag', 'id_ever_tag', $tagId)) {
+                $this->addFieldError('post_tags', sprintf('Tag introuvable (id: %d).', $tagId));
+            }
+        }
+        $requestData['post_tags'] = $postTags;
+
+        $postProducts = $this->normalizeIntCollection($requestData['post_products'] ?? []);
+        foreach ($postProducts as $productId) {
+            if (!$this->existsInPrestashopTable('product', 'id_product', $productId)) {
+                $this->addFieldError('post_products', sprintf('Produit introuvable (id: %d).', $productId));
+            }
+        }
+        $requestData['post_products'] = $postProducts;
+
+        $this->throwIfInvalid();
+
         return $requestData;
     }
 }

--- a/src/Application/Blog/RequestValidationException.php
+++ b/src/Application/Blog/RequestValidationException.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace PrestaShop\Module\Everpsblog\Application\Blog;
+
+use InvalidArgumentException;
+
+class RequestValidationException extends InvalidArgumentException
+{
+    /** @var array<string, string[]> */
+    private $fieldErrors;
+
+    /** @var string[] */
+    private $globalErrors;
+
+    /**
+     * @param array<string, string[]> $fieldErrors
+     * @param string[] $globalErrors
+     */
+    public function __construct(array $fieldErrors = [], array $globalErrors = [])
+    {
+        $this->fieldErrors = $fieldErrors;
+        $this->globalErrors = $globalErrors;
+
+        parent::__construct($this->buildMessage());
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function getFieldErrors(): array
+    {
+        return $this->fieldErrors;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getGlobalErrors(): array
+    {
+        return $this->globalErrors;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'global' => $this->globalErrors,
+            'fields' => $this->fieldErrors,
+        ];
+    }
+
+    private function buildMessage(): string
+    {
+        $parts = [];
+
+        foreach ($this->globalErrors as $error) {
+            $parts[] = $error;
+        }
+
+        foreach ($this->fieldErrors as $field => $errors) {
+            foreach ($errors as $error) {
+                $parts[] = sprintf('%s: %s', $field, $error);
+            }
+        }
+
+        if (empty($parts)) {
+            return 'Invalid request data.';
+        }
+
+        return implode(' ', $parts);
+    }
+}

--- a/src/Application/Blog/TagRequestValidator.php
+++ b/src/Application/Blog/TagRequestValidator.php
@@ -2,10 +2,17 @@
 
 namespace PrestaShop\Module\Everpsblog\Application\Blog;
 
-class TagRequestValidator
+class TagRequestValidator extends AbstractRequestValidator
 {
     public function validate(array $requestData): array
     {
+        $this->resetErrors();
+
+        $this->ensureDefaultTitle($requestData);
+        $requestData = $this->normalizeSeoFields($requestData);
+
+        $this->throwIfInvalid();
+
         return $requestData;
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single, reusable validation layer for blog-related commands so the UI can get structured, field-aware errors and server-side inputs are consistently normalized.
- Enforce minimal mandatory fields per resource (e.g. default-language title), SEO constraints, publication status/date coherence, and relational ID existence checks to avoid invalid writes.

### Description
- Add `AbstractRequestValidator` with shared helpers for language handling, SEO normalization (meta length + slug normalization), status/date coherence, relation existence checks, normalization of integer collections and structured error aggregation. (new file `src/Application/Blog/AbstractRequestValidator.php`)
- Add `RequestValidationException` that exposes `fields` and `global` errors and provides `toArray()` for UI/API consumption. (new file `src/Application/Blog/RequestValidationException.php`)
- Make resource validators extend the abstract validator and implement rules and normalizations for each resource: `PostRequestValidator` (title required in default language, SEO normalization, status/date adjustment, check author/category/tag/product IDs), `CategoryRequestValidator` (default title + SEO + parent existence), `TagRequestValidator` (default title + SEO), `AuthorRequestValidator` (required `nickhandle`, SEO, optional employee existence), and `CommentRequestValidator` (required/existing `id_ever_post`, required nickname/content and normalization to `name`/`comment`). (modified files under `src/Application/Blog/`)
- Validators now collect per-field messages and global messages and throw `RequestValidationException` when invalid, otherwise they return normalized request data (e.g. normalized slugs, arrays of ints, adjusted `post_status`).

### Testing
- Performed PHP syntax checks with `php -l` on all new and modified validator classes and the exception class and all reported "No syntax errors detected".
- No automated unit tests existed for these validators, so only syntax/static checks were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e236a832788322ad21ddef562be9e1)