### PR TITLE
Add cancel and "Save and stay" actions to admin create/edit forms

### DIFF
--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -66,10 +66,15 @@ class AuthorController extends AbstractDomainController
                     $savedAuthorId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $authorId, (array) $form->getData()))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+                    $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Auteur mis à jour.' : 'Auteur créé.');
 
-                    return $this->redirectToRoute('everpsblog_admin_author_edit', ['authorId' => $savedAuthorId]);
+                    if ('save_and_stay' === $submitAction) {
+                        return $this->redirectToRoute('everpsblog_admin_author_edit', ['authorId' => $savedAuthorId]);
+                    }
+
+                    return $this->redirectToRoute('everpsblog_admin_author');
                 } catch (\Throwable $exception) {
                     $form->addError(new FormError('Impossible d\'enregistrer l\'auteur.'));
                 }
@@ -82,6 +87,7 @@ class AuthorController extends AbstractDomainController
             'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'author',
+            'cancelUrl' => $this->generateUrl('everpsblog_admin_author'),
             'createUrl' => $this->generateUrl('everpsblog_admin_author_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -68,10 +68,15 @@ class CategoryController extends AbstractDomainController
                     $savedCategoryId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $categoryId, $data))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate($data));
+                    $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Catégorie mise à jour.' : 'Catégorie créée.');
 
-                    return $this->redirectToRoute('everpsblog_admin_category_edit', ['categoryId' => $savedCategoryId]);
+                    if ('save_and_stay' === $submitAction) {
+                        return $this->redirectToRoute('everpsblog_admin_category_edit', ['categoryId' => $savedCategoryId]);
+                    }
+
+                    return $this->redirectToRoute('everpsblog_admin_category');
                 } catch (\Throwable $exception) {
                     $form->addError(new FormError('Impossible d\'enregistrer la catégorie.'));
                 }
@@ -84,6 +89,7 @@ class CategoryController extends AbstractDomainController
             'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'category',
+            'cancelUrl' => $this->generateUrl('everpsblog_admin_category'),
             'createUrl' => $this->generateUrl('everpsblog_admin_category_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);

--- a/src/Controller/Admin/CommentController.php
+++ b/src/Controller/Admin/CommentController.php
@@ -66,10 +66,15 @@ class CommentController extends AbstractDomainController
                     $savedCommentId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $commentId, (array) $form->getData()))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+                    $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Commentaire mis à jour.' : 'Commentaire créé.');
 
-                    return $this->redirectToRoute('everpsblog_admin_comment_edit', ['commentId' => $savedCommentId]);
+                    if ('save_and_stay' === $submitAction) {
+                        return $this->redirectToRoute('everpsblog_admin_comment_edit', ['commentId' => $savedCommentId]);
+                    }
+
+                    return $this->redirectToRoute('everpsblog_admin_comment');
                 } catch (\Throwable $exception) {
                     $form->addError(new FormError('Impossible d\'enregistrer le commentaire.'));
                 }
@@ -82,6 +87,7 @@ class CommentController extends AbstractDomainController
             'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'comment',
+            'cancelUrl' => $this->generateUrl('everpsblog_admin_comment'),
             'createUrl' => $this->generateUrl('everpsblog_admin_comment_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -79,10 +79,15 @@ class PostController extends AbstractDomainController
                     $savedPostId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $postId, $postData))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate($postData));
+                    $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Article mis à jour.' : 'Article créé.');
 
-                    return $this->redirectToRoute('everpsblog_admin_post_edit', ['postId' => $savedPostId]);
+                    if ('save_and_stay' === $submitAction) {
+                        return $this->redirectToRoute('everpsblog_admin_post_edit', ['postId' => $savedPostId]);
+                    }
+
+                    return $this->redirectToRoute('everpsblog_admin_post');
                 } catch (\Throwable $exception) {
                     $form->addError(new FormError('Impossible d\'enregistrer l\'article.'));
                     $this->addFlash('error', 'Impossible d\'enregistrer l\'article.');
@@ -96,6 +101,7 @@ class PostController extends AbstractDomainController
             'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'post',
+            'cancelUrl' => $this->generateUrl('everpsblog_admin_post'),
             'createUrl' => $this->generateUrl('everpsblog_admin_post_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -66,10 +66,15 @@ class TagController extends AbstractDomainController
                     $savedTagId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $tagId, (array) $form->getData()))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate((array) $form->getData()));
+                    $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Tag mis à jour.' : 'Tag créé.');
 
-                    return $this->redirectToRoute('everpsblog_admin_tag_edit', ['tagId' => $savedTagId]);
+                    if ('save_and_stay' === $submitAction) {
+                        return $this->redirectToRoute('everpsblog_admin_tag_edit', ['tagId' => $savedTagId]);
+                    }
+
+                    return $this->redirectToRoute('everpsblog_admin_tag');
                 } catch (\Throwable $exception) {
                     $form->addError(new FormError('Impossible d\'enregistrer le tag.'));
                 }
@@ -82,6 +87,7 @@ class TagController extends AbstractDomainController
             'csrfTokenId' => $csrfTokenId,
             'form' => $form->createView(),
             'currentResource' => 'tag',
+            'cancelUrl' => $this->generateUrl('everpsblog_admin_tag'),
             'createUrl' => $this->generateUrl('everpsblog_admin_tag_form'),
             'navigationLinks' => $this->getAdminNavigationLinks(),
         ]);

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -20,7 +20,11 @@
         <input type="hidden" name="_csrf_token" value="{{ csrf_token(csrfTokenId) }}">
       {% endif %}
       {{ form_widget(form) }}
-      <button type="submit" class="btn btn-primary">Enregistrer</button>
+      <div class="d-flex flex-wrap">
+        <a class="btn btn-outline-secondary mr-2 mb-2" href="{{ cancelUrl }}">Annuler</a>
+        <button type="submit" class="btn btn-primary mr-2 mb-2" name="_submit_action" value="save">Enregistrer</button>
+        <button type="submit" class="btn btn-primary" name="_submit_action" value="save_and_stay">Enregistrer et rester</button>
+      </div>
       {{ form_end(form) }}
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Improve admin UX by adding explicit "Annuler" and "Enregistrer et rester" actions on modern admin create/edit forms so users can either return to the list or remain on the edited entity after saving.

### Description
- Updated the admin form template `views/templates/admin/modern/form.html.twig` to render a `cancel` link and two submit buttons wired with `_submit_action` values `save` and `save_and_stay`.
- Updated admin form controllers `src/Controller/Admin/{Post,Category,Tag,Author,Comment}Controller.php` to read the `_submit_action` request value and conditionally redirect to the edit page only when the action is `save_and_stay`, otherwise redirect to the resource listing.
- Exposed a `cancelUrl` template variable from each controller so the template `Annuler` button points back to the resource list.

### Testing
- Static syntax checks executed with `php -l` for the modified controllers: `AuthorController.php`, `CategoryController.php`, `CommentController.php`, `PostController.php`, and `TagController.php`, and all reported no syntax errors.
- Verified template and controller changes together by running the codebase type/syntax checks (no runtime integration tests available in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e237bfae1c8322a60483919966eef3)