### PR TITLE
Modernize grid data action URLs and add bulk endpoint metadata

### DIFF
--- a/src/Grid/Data/AuthorGridDataFactory.php
+++ b/src/Grid/Data/AuthorGridDataFactory.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\Everpsblog\Grid\Data;
 use PrestaShop\Module\Everpsblog\Core\Grid\GridData;
 use PrestaShop\Module\Everpsblog\Repository\AuthorRepository;
 use PrestaShop\Module\Everpsblog\Service\AdminRouteSigner;
+use Symfony\Component\Routing\RouterInterface;
 
 final class AuthorGridDataFactory
 {
@@ -12,11 +13,26 @@ final class AuthorGridDataFactory
     private $authorRepository;
     /** @var AdminRouteSigner */
     private $routeSigner;
+    /** @var RouterInterface */
+    private $router;
+    /** @var bool */
+    private $useLegacyFallback;
+    /** @var bool */
+    private $useModernDeleteAction;
 
-    public function __construct(AuthorRepository $authorRepository, AdminRouteSigner $routeSigner)
+    public function __construct(
+        AuthorRepository $authorRepository,
+        AdminRouteSigner $routeSigner,
+        RouterInterface $router,
+        bool $useLegacyFallback = true,
+        bool $useModernDeleteAction = false
+    )
     {
         $this->authorRepository = $authorRepository;
         $this->routeSigner = $routeSigner;
+        $this->router = $router;
+        $this->useLegacyFallback = $useLegacyFallback;
+        $this->useModernDeleteAction = $useModernDeleteAction;
     }
 
     /**
@@ -38,11 +54,49 @@ final class AuthorGridDataFactory
         foreach ($records as &$record) {
             $id = (int) $record['id_ever_author'];
             $record['_actions'] = [
-                'edit' => $this->routeSigner->sign('AdminEverPsBlogAuthor', ['updateauthor' => $id]),
-                'delete' => $this->routeSigner->sign('AdminEverPsBlogAuthor', ['deleteauthor' => $id]),
+                'edit' => $this->resolveUrl(
+                    'everpsblog_admin_author_edit',
+                    ['authorId' => $id],
+                    'AdminEverPsBlogAuthor',
+                    ['updateauthor' => $id]
+                ),
+                'delete' => $this->useModernDeleteAction
+                    ? $this->resolveUrl('everpsblog_admin_author_delete', ['authorId' => $id], 'AdminEverPsBlogAuthor', ['deleteauthor' => $id])
+                    : $this->routeSigner->sign('AdminEverPsBlogAuthor', ['deleteauthor' => $id]),
+                'delete_legacy' => $this->routeSigner->sign('AdminEverPsBlogAuthor', ['deleteauthor' => $id]),
+            ];
+            $record['_bulk_actions'] = [
+                'delete' => $this->resolveBulkActionUrl('everpsblog_admin_author_bulk_delete', 'AdminEverPsBlogAuthor'),
             ];
         }
 
         return new GridData($records);
+    }
+
+    /**
+     * @param array<string, mixed> $modernParameters
+     * @param array<string, mixed> $legacyParameters
+     */
+    private function resolveUrl(string $modernRoute, array $modernParameters, string $legacyController, array $legacyParameters): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute, $modernParameters);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController, $legacyParameters) : '';
+    }
+
+    private function resolveBulkActionUrl(string $modernRoute, string $legacyController): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController) : '';
+    }
+
+    private function routeExists(string $routeName): bool
+    {
+        return null !== $this->router->getRouteCollection()->get($routeName);
     }
 }

--- a/src/Grid/Data/CategoryGridDataFactory.php
+++ b/src/Grid/Data/CategoryGridDataFactory.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\Everpsblog\Grid\Data;
 use PrestaShop\Module\Everpsblog\Core\Grid\GridData;
 use PrestaShop\Module\Everpsblog\Repository\CategoryRepository;
 use PrestaShop\Module\Everpsblog\Service\AdminRouteSigner;
+use Symfony\Component\Routing\RouterInterface;
 
 final class CategoryGridDataFactory
 {
@@ -12,11 +13,26 @@ final class CategoryGridDataFactory
     private $categoryRepository;
     /** @var AdminRouteSigner */
     private $routeSigner;
+    /** @var RouterInterface */
+    private $router;
+    /** @var bool */
+    private $useLegacyFallback;
+    /** @var bool */
+    private $useModernDeleteAction;
 
-    public function __construct(CategoryRepository $categoryRepository, AdminRouteSigner $routeSigner)
+    public function __construct(
+        CategoryRepository $categoryRepository,
+        AdminRouteSigner $routeSigner,
+        RouterInterface $router,
+        bool $useLegacyFallback = true,
+        bool $useModernDeleteAction = false
+    )
     {
         $this->categoryRepository = $categoryRepository;
         $this->routeSigner = $routeSigner;
+        $this->router = $router;
+        $this->useLegacyFallback = $useLegacyFallback;
+        $this->useModernDeleteAction = $useModernDeleteAction;
     }
 
     /**
@@ -38,11 +54,49 @@ final class CategoryGridDataFactory
         foreach ($records as &$record) {
             $id = (int) $record['id_ever_category'];
             $record['_actions'] = [
-                'edit' => $this->routeSigner->sign('AdminEverPsBlogCategory', ['updatecategory' => $id]),
-                'delete' => $this->routeSigner->sign('AdminEverPsBlogCategory', ['deletecategory' => $id]),
+                'edit' => $this->resolveUrl(
+                    'everpsblog_admin_category_edit',
+                    ['categoryId' => $id],
+                    'AdminEverPsBlogCategory',
+                    ['updatecategory' => $id]
+                ),
+                'delete' => $this->useModernDeleteAction
+                    ? $this->resolveUrl('everpsblog_admin_category_delete', ['categoryId' => $id], 'AdminEverPsBlogCategory', ['deletecategory' => $id])
+                    : $this->routeSigner->sign('AdminEverPsBlogCategory', ['deletecategory' => $id]),
+                'delete_legacy' => $this->routeSigner->sign('AdminEverPsBlogCategory', ['deletecategory' => $id]),
+            ];
+            $record['_bulk_actions'] = [
+                'delete' => $this->resolveBulkActionUrl('everpsblog_admin_category_bulk_delete', 'AdminEverPsBlogCategory'),
             ];
         }
 
         return new GridData($records);
+    }
+
+    /**
+     * @param array<string, mixed> $modernParameters
+     * @param array<string, mixed> $legacyParameters
+     */
+    private function resolveUrl(string $modernRoute, array $modernParameters, string $legacyController, array $legacyParameters): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute, $modernParameters);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController, $legacyParameters) : '';
+    }
+
+    private function resolveBulkActionUrl(string $modernRoute, string $legacyController): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController) : '';
+    }
+
+    private function routeExists(string $routeName): bool
+    {
+        return null !== $this->router->getRouteCollection()->get($routeName);
     }
 }

--- a/src/Grid/Data/CommentGridDataFactory.php
+++ b/src/Grid/Data/CommentGridDataFactory.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\Everpsblog\Grid\Data;
 use PrestaShop\Module\Everpsblog\Core\Grid\GridData;
 use PrestaShop\Module\Everpsblog\Repository\CommentRepository;
 use PrestaShop\Module\Everpsblog\Service\AdminRouteSigner;
+use Symfony\Component\Routing\RouterInterface;
 
 final class CommentGridDataFactory
 {
@@ -12,11 +13,26 @@ final class CommentGridDataFactory
     private $commentRepository;
     /** @var AdminRouteSigner */
     private $routeSigner;
+    /** @var RouterInterface */
+    private $router;
+    /** @var bool */
+    private $useLegacyFallback;
+    /** @var bool */
+    private $useModernDeleteAction;
 
-    public function __construct(CommentRepository $commentRepository, AdminRouteSigner $routeSigner)
+    public function __construct(
+        CommentRepository $commentRepository,
+        AdminRouteSigner $routeSigner,
+        RouterInterface $router,
+        bool $useLegacyFallback = true,
+        bool $useModernDeleteAction = false
+    )
     {
         $this->commentRepository = $commentRepository;
         $this->routeSigner = $routeSigner;
+        $this->router = $router;
+        $this->useLegacyFallback = $useLegacyFallback;
+        $this->useModernDeleteAction = $useModernDeleteAction;
     }
 
     /**
@@ -38,11 +54,50 @@ final class CommentGridDataFactory
         foreach ($records as &$record) {
             $id = (int) $record['id_ever_comment'];
             $record['_actions'] = [
-                'edit' => $this->routeSigner->sign('AdminEverPsBlogComment', ['updatecomment' => $id]),
-                'delete' => $this->routeSigner->sign('AdminEverPsBlogComment', ['deletecomment' => $id]),
+                'edit' => $this->resolveUrl(
+                    'everpsblog_admin_comment_edit',
+                    ['commentId' => $id],
+                    'AdminEverPsBlogComment',
+                    ['updatecomment' => $id]
+                ),
+                'delete' => $this->useModernDeleteAction
+                    ? $this->resolveUrl('everpsblog_admin_comment_delete', ['commentId' => $id], 'AdminEverPsBlogComment', ['deletecomment' => $id])
+                    : $this->routeSigner->sign('AdminEverPsBlogComment', ['deletecomment' => $id]),
+                'delete_legacy' => $this->routeSigner->sign('AdminEverPsBlogComment', ['deletecomment' => $id]),
+            ];
+            $record['_bulk_actions'] = [
+                'delete' => $this->resolveBulkActionUrl('everpsblog_admin_comment_bulk_delete', 'AdminEverPsBlogComment'),
+                'approveall' => $this->resolveBulkActionUrl('everpsblog_admin_comment_bulk_approve', 'AdminEverPsBlogComment'),
             ];
         }
 
         return new GridData($records);
+    }
+
+    /**
+     * @param array<string, mixed> $modernParameters
+     * @param array<string, mixed> $legacyParameters
+     */
+    private function resolveUrl(string $modernRoute, array $modernParameters, string $legacyController, array $legacyParameters): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute, $modernParameters);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController, $legacyParameters) : '';
+    }
+
+    private function resolveBulkActionUrl(string $modernRoute, string $legacyController): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController) : '';
+    }
+
+    private function routeExists(string $routeName): bool
+    {
+        return null !== $this->router->getRouteCollection()->get($routeName);
     }
 }

--- a/src/Grid/Data/PostGridDataFactory.php
+++ b/src/Grid/Data/PostGridDataFactory.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\Everpsblog\Grid\Data;
 use PrestaShop\Module\Everpsblog\Core\Grid\GridData;
 use PrestaShop\Module\Everpsblog\Repository\PostRepository;
 use PrestaShop\Module\Everpsblog\Service\AdminRouteSigner;
+use Symfony\Component\Routing\RouterInterface;
 
 final class PostGridDataFactory
 {
@@ -12,11 +13,26 @@ final class PostGridDataFactory
     private $postRepository;
     /** @var AdminRouteSigner */
     private $routeSigner;
+    /** @var RouterInterface */
+    private $router;
+    /** @var bool */
+    private $useLegacyFallback;
+    /** @var bool */
+    private $useModernDeleteAction;
 
-    public function __construct(PostRepository $postRepository, AdminRouteSigner $routeSigner)
+    public function __construct(
+        PostRepository $postRepository,
+        AdminRouteSigner $routeSigner,
+        RouterInterface $router,
+        bool $useLegacyFallback = true,
+        bool $useModernDeleteAction = false
+    )
     {
         $this->postRepository = $postRepository;
         $this->routeSigner = $routeSigner;
+        $this->router = $router;
+        $this->useLegacyFallback = $useLegacyFallback;
+        $this->useModernDeleteAction = $useModernDeleteAction;
     }
 
     /**
@@ -39,11 +55,50 @@ final class PostGridDataFactory
         foreach ($records as &$record) {
             $id = (int) $record['id_ever_post'];
             $record['_actions'] = [
-                'edit' => $this->routeSigner->sign('AdminEverPsBlogPost', ['updatepost' => $id]),
-                'delete' => $this->routeSigner->sign('AdminEverPsBlogPost', ['deletepost' => $id]),
+                'edit' => $this->resolveUrl(
+                    'everpsblog_admin_post_edit',
+                    ['postId' => $id],
+                    'AdminEverPsBlogPost',
+                    ['updatepost' => $id]
+                ),
+                'delete' => $this->useModernDeleteAction
+                    ? $this->resolveUrl('everpsblog_admin_post_delete', ['postId' => $id], 'AdminEverPsBlogPost', ['deletepost' => $id])
+                    : $this->routeSigner->sign('AdminEverPsBlogPost', ['deletepost' => $id]),
+                'delete_legacy' => $this->routeSigner->sign('AdminEverPsBlogPost', ['deletepost' => $id]),
+            ];
+            $record['_bulk_actions'] = [
+                'delete' => $this->resolveBulkActionUrl('everpsblog_admin_post_bulk_delete', 'AdminEverPsBlogPost'),
+                'publishall' => $this->resolveBulkActionUrl('everpsblog_admin_post_bulk_publish', 'AdminEverPsBlogPost'),
             ];
         }
 
         return new GridData($records);
+    }
+
+    /**
+     * @param array<string, mixed> $modernParameters
+     * @param array<string, mixed> $legacyParameters
+     */
+    private function resolveUrl(string $modernRoute, array $modernParameters, string $legacyController, array $legacyParameters): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute, $modernParameters);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController, $legacyParameters) : '';
+    }
+
+    private function resolveBulkActionUrl(string $modernRoute, string $legacyController): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController) : '';
+    }
+
+    private function routeExists(string $routeName): bool
+    {
+        return null !== $this->router->getRouteCollection()->get($routeName);
     }
 }

--- a/src/Grid/Data/TagGridDataFactory.php
+++ b/src/Grid/Data/TagGridDataFactory.php
@@ -5,6 +5,7 @@ namespace PrestaShop\Module\Everpsblog\Grid\Data;
 use PrestaShop\Module\Everpsblog\Core\Grid\GridData;
 use PrestaShop\Module\Everpsblog\Repository\TagRepository;
 use PrestaShop\Module\Everpsblog\Service\AdminRouteSigner;
+use Symfony\Component\Routing\RouterInterface;
 
 final class TagGridDataFactory
 {
@@ -12,11 +13,26 @@ final class TagGridDataFactory
     private $tagRepository;
     /** @var AdminRouteSigner */
     private $routeSigner;
+    /** @var RouterInterface */
+    private $router;
+    /** @var bool */
+    private $useLegacyFallback;
+    /** @var bool */
+    private $useModernDeleteAction;
 
-    public function __construct(TagRepository $tagRepository, AdminRouteSigner $routeSigner)
+    public function __construct(
+        TagRepository $tagRepository,
+        AdminRouteSigner $routeSigner,
+        RouterInterface $router,
+        bool $useLegacyFallback = true,
+        bool $useModernDeleteAction = false
+    )
     {
         $this->tagRepository = $tagRepository;
         $this->routeSigner = $routeSigner;
+        $this->router = $router;
+        $this->useLegacyFallback = $useLegacyFallback;
+        $this->useModernDeleteAction = $useModernDeleteAction;
     }
 
     /**
@@ -38,11 +54,49 @@ final class TagGridDataFactory
         foreach ($records as &$record) {
             $id = (int) $record['id_ever_tag'];
             $record['_actions'] = [
-                'edit' => $this->routeSigner->sign('AdminEverPsBlogTag', ['updatetag' => $id]),
-                'delete' => $this->routeSigner->sign('AdminEverPsBlogTag', ['deletetag' => $id]),
+                'edit' => $this->resolveUrl(
+                    'everpsblog_admin_tag_edit',
+                    ['tagId' => $id],
+                    'AdminEverPsBlogTag',
+                    ['updatetag' => $id]
+                ),
+                'delete' => $this->useModernDeleteAction
+                    ? $this->resolveUrl('everpsblog_admin_tag_delete', ['tagId' => $id], 'AdminEverPsBlogTag', ['deletetag' => $id])
+                    : $this->routeSigner->sign('AdminEverPsBlogTag', ['deletetag' => $id]),
+                'delete_legacy' => $this->routeSigner->sign('AdminEverPsBlogTag', ['deletetag' => $id]),
+            ];
+            $record['_bulk_actions'] = [
+                'delete' => $this->resolveBulkActionUrl('everpsblog_admin_tag_bulk_delete', 'AdminEverPsBlogTag'),
             ];
         }
 
         return new GridData($records);
+    }
+
+    /**
+     * @param array<string, mixed> $modernParameters
+     * @param array<string, mixed> $legacyParameters
+     */
+    private function resolveUrl(string $modernRoute, array $modernParameters, string $legacyController, array $legacyParameters): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute, $modernParameters);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController, $legacyParameters) : '';
+    }
+
+    private function resolveBulkActionUrl(string $modernRoute, string $legacyController): string
+    {
+        if ($this->routeExists($modernRoute)) {
+            return $this->router->generate($modernRoute);
+        }
+
+        return $this->useLegacyFallback ? $this->routeSigner->sign($legacyController) : '';
+    }
+
+    private function routeExists(string $routeName): bool
+    {
+        return null !== $this->router->getRouteCollection()->get($routeName);
     }
 }


### PR DESCRIPTION
### Motivation
- Migrate grid row action URLs to modern Symfony admin routes (`everpsblog_admin_*_edit` / delete) while keeping optional legacy compatibility for PrestaShop legacy controllers. 
- Standardize mass (bulk) actions to point to dedicated modern endpoints when available. 
- Make migration configurable so installations can enable modern endpoints incrementally without breaking legacy Admin links.

### Description
- Injected `RouterInterface` into the five BO grid data factories and added `useLegacyFallback` and `useModernDeleteAction` constructor flags to make URL strategy configurable. 
- Replaced direct legacy-signed `_actions.edit` URLs with `resolveUrl()` that prefers modern routes (`everpsblog_admin_*_edit`) and falls back to signed legacy links when configured. 
- Made delete action pluggable: when `useModernDeleteAction` is enabled factories will resolve modern delete routes, and a `delete_legacy` entry is kept for explicit compatibility. 
- Added normalized per-row `_bulk_actions` metadata and `resolveBulkActionUrl()` helper to point to modern bulk endpoints when present, otherwise fall back to legacy signed URLs; added `routeExists()` utility to detect declared routes.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files (`src/Grid/Data/PostGridDataFactory.php`, `CategoryGridDataFactory.php`, `TagGridDataFactory.php`, `AuthorGridDataFactory.php`, `CommentGridDataFactory.php`) and they reported no syntax errors. 
- No other automated tests were available/ran in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e23aacb73c83228c8bdbbac44ebd1a)