### PR TITLE
Add featured image upload to admin post form

### DIFF
--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -10,6 +10,9 @@ use PrestaShop\Module\Everpsblog\Form\Type\Admin\PostType;
 use PrestaShop\Module\Everpsblog\Grid\Data\PostGridDataFactory;
 use PrestaShop\Module\Everpsblog\Grid\Definition\PostGridDefinitionFactory;
 use PrestaShop\Module\Everpsblog\Service\Audit\SensitiveActionLogger;
+use PrestaShop\Module\Everpsblog\Service\BlogImageService;
+use PrestaShop\Module\Everpsblog\Service\ImageUploader;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -23,6 +26,8 @@ class PostController extends AbstractDomainController
     private $dataFactory;
     private $formDataProvider;
     private $sensitiveActionLogger;
+    private $blogImageService;
+    private $imageUploader;
 
     public function __construct(
         \PrestaShop\Module\Everpsblog\Service\ContextStateService $contextStateService,
@@ -31,7 +36,9 @@ class PostController extends AbstractDomainController
         PostGridDefinitionFactory $definitionFactory,
         PostGridDataFactory $dataFactory,
         PostFormDataProvider $formDataProvider,
-        SensitiveActionLogger $sensitiveActionLogger
+        SensitiveActionLogger $sensitiveActionLogger,
+        BlogImageService $blogImageService,
+        ImageUploader $imageUploader
     ) {
         parent::__construct($contextStateService);
         $this->commandBus = $commandBus;
@@ -40,6 +47,8 @@ class PostController extends AbstractDomainController
         $this->dataFactory = $dataFactory;
         $this->formDataProvider = $formDataProvider;
         $this->sensitiveActionLogger = $sensitiveActionLogger;
+        $this->blogImageService = $blogImageService;
+        $this->imageUploader = $imageUploader;
     }
 
     public function indexAction(Request $request): Response
@@ -61,11 +70,13 @@ class PostController extends AbstractDomainController
     {
         $isEdit = null !== $postId;
         $csrfTokenId = $isEdit ? 'everpsblog_post_update_' . $postId : 'everpsblog_post_create';
+        $featuredImageHelp = $isEdit ? $this->buildFeaturedImageHelp((int) $postId) : '';
         $form = $this->createForm(PostType::class, $this->formDataProvider->getData($postId), [
             'method' => Request::METHOD_POST,
             'action' => $isEdit
                 ? $this->generateUrl('everpsblog_admin_post_edit', ['postId' => $postId])
                 : $this->generateUrl('everpsblog_admin_post_form'),
+            'featured_image_help' => $featuredImageHelp,
         ]);
         $form->handleRequest($request);
 
@@ -79,6 +90,7 @@ class PostController extends AbstractDomainController
                     $savedPostId = $isEdit
                         ? $this->commandBus->handle($this->commandAssembler->assembleUpdate((int) $postId, $postData))
                         : $this->commandBus->handle($this->commandAssembler->assembleCreate($postData));
+                    $this->handleFeaturedImageUpload($form->get('publication_tab')->get('featured_image_file')->getData(), (int) $savedPostId);
                     $submitAction = (string) $request->request->get('_submit_action', 'save');
 
                     $this->addFlash('success', $isEdit ? 'Article mis à jour.' : 'Article créé.');
@@ -149,5 +161,61 @@ class PostController extends AbstractDomainController
         if (!$this->isCsrfTokenValid($tokenId, $token)) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
+    }
+
+    private function handleFeaturedImageUpload($uploadedImage, int $postId): void
+    {
+        if (!$uploadedImage instanceof UploadedFile) {
+            return;
+        }
+
+        $shopId = $this->getContextShopId();
+        $extension = strtolower((string) ($uploadedImage->guessExtension() ?: $uploadedImage->getClientOriginalExtension() ?: 'jpg'));
+        if (!in_array($extension, ['jpg', 'jpeg', 'png', 'gif', 'webp'], true)) {
+            throw new \RuntimeException('Format d\'image non pris en charge.');
+        }
+
+        $targetDirectory = rtrim(_PS_IMG_DIR_, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'post';
+        if (!is_dir($targetDirectory) && !@mkdir($targetDirectory, 0755, true) && !is_dir($targetDirectory)) {
+            throw new \RuntimeException('Impossible de créer le dossier de destination des images.');
+        }
+
+        foreach ((array) glob($targetDirectory . DIRECTORY_SEPARATOR . $postId . '.*') as $existingFile) {
+            @unlink($existingFile);
+        }
+
+        $targetFileName = sprintf('%d.%s', $postId, $extension);
+        $this->imageUploader->upload($uploadedImage, $targetDirectory, $targetFileName);
+
+        $image = $this->blogImageService->getBlogImage($postId, $shopId, 'post');
+        if (!\Validate::isLoadedObject($image)) {
+            $image = $this->blogImageService->createImageModel();
+        }
+
+        $image->id_element = $postId;
+        $image->id_shop = $shopId;
+        $image->image_type = 'post';
+        $image->image_link = 'img/post/' . $targetFileName;
+        if (!(bool) $image->save()) {
+            throw new \RuntimeException('Impossible d\'enregistrer la référence de l\'image.');
+        }
+
+        $this->blogImageService->clearCache();
+    }
+
+    private function buildFeaturedImageHelp(int $postId): string
+    {
+        $shopId = $this->getContextShopId();
+        $image = $this->blogImageService->getBlogImage($postId, $shopId, 'post');
+        if (!\Validate::isLoadedObject($image)) {
+            return '';
+        }
+        $url = (string) $this->blogImageService->getBlogImageUrl($postId, $shopId, 'post');
+
+        return sprintf(
+            'Image actuelle : <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+            htmlspecialchars($url, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($url, ENT_QUOTES, 'UTF-8')
+        );
     }
 }

--- a/src/Form/Type/Admin/PostType.php
+++ b/src/Form/Type/Admin/PostType.php
@@ -6,11 +6,13 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class PostType extends AbstractType
 {
@@ -18,7 +20,7 @@ final class PostType extends AbstractType
     {
         $this->buildContentTab($builder);
         $this->buildSeoTab($builder);
-        $this->buildPublicationTab($builder);
+        $this->buildPublicationTab($builder, $options);
         $this->buildTaxonomyTab($builder);
     }
 
@@ -100,7 +102,7 @@ final class PostType extends AbstractType
         $builder->add($seoTab);
     }
 
-    private function buildPublicationTab(FormBuilderInterface $builder): void
+    private function buildPublicationTab(FormBuilderInterface $builder, array $options): void
     {
         $publicationTab = $builder->create('publication_tab', FormType::class, [
             'inherit_data' => true,
@@ -139,6 +141,13 @@ final class PostType extends AbstractType
                 'required' => false,
                 'label' => 'Mot de passe',
                 'empty_data' => '',
+            ])
+            ->add('featured_image_file', FileType::class, [
+                'required' => false,
+                'mapped' => false,
+                'label' => 'Image à la une',
+                'help' => $options['featured_image_help'],
+                'help_html' => true,
             ])
         ;
 
@@ -307,5 +316,13 @@ final class PostType extends AbstractType
         }
 
         return $choices;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'featured_image_help' => '',
+        ]);
+        $resolver->setAllowedTypes('featured_image_help', 'string');
     }
 }


### PR DESCRIPTION
### Motivation
- Le formulaire d'édition/création d'article ne permettait pas de téléverser une image à la une depuis le back-office moderne, empêchant la configuration d'une `featured image` pour un article. 
- Il faut pouvoir stocker le fichier sur le disque, référencer la ligne correspondante dans `ever_blog_image` et invalider le cache pour que l'image soit immédiatement disponible en front.

### Description
- Ajout d'un champ de fichier non mappé `featured_image_file` dans le formulaire d'article (onglet Publication) via `src/Form/Type/Admin/PostType.php` et d'une option de formulaire `featured_image_help` pour afficher le lien vers l'image actuelle. 
- Traitement côté contrôleur dans `src/Controller/Admin/PostController.php` pour prendre en charge l'upload après création/mise à jour : validation d'extension, suppression des fichiers existants pour l'ID de post, enregistrement physique dans `img/post/{postId}.{ext}` et upsert de la ligne `ever_blog_image` (`image_type = 'post'`).
- Utilisation des services existants `BlogImageService` et `ImageUploader` pour persister la référence et gérer le cache, plus affichage d'un lien « Image actuelle » sur l'édition d'un article.
- Contraintes et comportements : extensions acceptées `jpg|jpeg|png|gif|webp`, suppression des fichiers précédents pour éviter les conflits d'extension, et invalidation du cache image après sauvegarde.

### Testing
- Syntactic checks: `php -l src/Form/Type/Admin/PostType.php` succeeded. 
- Syntactic checks: `php -l src/Controller/Admin/PostController.php` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24090a8308322a9b8ffe9bd8b4d20)