### PR TITLE
Fix admin language switcher and slug auto-generation in modern form

### DIFF
--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -220,7 +220,7 @@
             </small>
           {% elseif fieldName starts with 'link_rewrite_' %}
             <div class="d-flex justify-content-end mb-2">
-              <button type="button" class="btn btn-sm btn-outline-secondary ever-generate-slug" data-target="{{ field.vars.id }}" data-lang-id="{{ fieldName|split('_')|last }}">
+              <button type="button" class="btn btn-sm btn-outline-secondary ever-generate-slug" data-target="{{ field.vars.id }}" data-lang-id="{{ field.vars.id|split('_')|last }}">
                 Auto-générer le slug
               </button>
             </div>
@@ -402,9 +402,21 @@
           .replace(/-+$/, '');
       }
 
-      function detectLangForField(fieldName) {
-        var match = fieldName.match(/_(\d+)$/);
+      function extractLangId(value) {
+        if (!value) {
+          return null;
+        }
+
+        var match = value.match(/_(\d+)(?:\]|$)/);
         return match ? match[1] : null;
+      }
+
+      function detectLangForField(field) {
+        if (!field) {
+          return null;
+        }
+
+        return extractLangId(field.getAttribute('name') || '') || extractLangId(field.id || '');
       }
 
       function updateCounter(input, counter) {
@@ -432,7 +444,7 @@
       Array.prototype.forEach.call(slugButtons, function (btn) {
         btn.addEventListener('click', function () {
           var target = getInput(btn.getAttribute('data-target'));
-          var langId = btn.getAttribute('data-lang-id');
+          var langId = extractLangId(btn.getAttribute('data-lang-id')) || btn.getAttribute('data-lang-id');
           var titleInput = getInputBySelector('[id$="_title_' + langId + '"]')
             || getInputBySelector('[id$="_meta_title_' + langId + '"]')
             || getInputBySelector('[id$="_nickhandle"]');
@@ -460,7 +472,7 @@
         });
 
         Array.prototype.forEach.call(fieldsWithLang, function (field) {
-          var lang = detectLangForField(field.getAttribute('name') || '');
+          var lang = detectLangForField(field);
           var wrapper = field.closest('.form-group, .form-control-group, .mb-3') || field.parentNode;
           if (!lang || !wrapper) {
             return;
@@ -475,7 +487,7 @@
           var langId = item.getAttribute('data-lang-id');
           var invalid = false;
           Array.prototype.forEach.call(fieldsWithLang, function (field) {
-            var lang = detectLangForField(field.getAttribute('name') || '');
+            var lang = detectLangForField(field);
             if (lang !== langId) {
               return;
             }


### PR DESCRIPTION
### Motivation
- The admin language selector and the "Auto-générer le slug" buttons were not affecting fields because language IDs were extracted only from Symfony-style `name` values, which fails for bracketed or underscore-suffixed IDs. 
- The goal is to reliably detect a field's language and to target the correct slug field regardless of whether the form field uses `name` or `id` wiring.

### Description
- Updated the slug button `data-lang-id` in `views/templates/admin/modern/form.html.twig` to derive the language part from `field.vars.id` instead of `field.vars.name` to produce a stable identifier for the button. 
- Added a robust JS helper `extractLangId(value)` that parses language IDs from both `_N` suffixes and Symfony bracketed names, and a `detectLangForField(field)` helper that inspects both the field `name` and `id`. 
- Replaced previous language-detection calls to use `detectLangForField(field)` and normalized `data-lang-id` when handling slug generation via `extractLangId(...) || ...` so slug buttons and language toggles now target the correct elements. 
- Adjusted slug generator and language visibility/validation logic in the same template so counters and event dispatching remain intact while language switching works as expected.

### Testing
- Verified occurrences and replacements with automated search using `rg` and inspected the modified template to ensure the new helpers and attribute changes were present and syntactically correct. 
- Executed the scripted update that performed the template edits and validated the resulting file content with line-oriented inspection (`nl`/file output), which showed the inserted `extractLangId`/`detectLangForField` functions and updated `data-lang-id`. 
- No automated unit tests exist for this UI template; the automated searches and file checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2417ce9288322b97be569e0a00860)