### PR TITLE
Fix BlogImageService autowiring in admin PostController

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -238,6 +238,9 @@ services:
     arguments:
       - '@cache.app'
 
+  PrestaShop\Module\Everpsblog\Service\BlogImageService:
+    alias: prestashop.module.everpsblog.service.blog_image
+
   prestashop.module.everpsblog.service.blog_sitemap:
     class: PrestaShop\Module\Everpsblog\Service\BlogSitemapService
     public: true


### PR DESCRIPTION
### Motivation
- Resolve a DI/autowiring error where `PrestaShop\Module\Everpsblog\Controller\Admin\PostController` requests `PrestaShop\Module\Everpsblog\Service\BlogImageService` by class but the container only exposed the service under the id `prestashop.module.everpsblog.service.blog_image`.

### Description
- Add a class alias in `config/services.yml` mapping `PrestaShop\Module\Everpsblog\Service\BlogImageService` to the existing `prestashop.module.everpsblog.service.blog_image` service id so constructor autowiring by type-hint works.

### Testing
- Ran `git diff -- config/services.yml`, `git status --short`, and committed the change, and the diff shows the alias present (commands completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e242e3faa883228831f71b2f1de7fd)