### PR TITLE
Fix ImageUploader autowiring in Admin PostController

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -248,6 +248,9 @@ services:
   prestashop.module.everpsblog.blog.image_uploader:
     class: PrestaShop\Module\Everpsblog\Service\ImageUploader
 
+  PrestaShop\Module\Everpsblog\Service\ImageUploader:
+    alias: prestashop.module.everpsblog.blog.image_uploader
+
   PrestaShop\Module\Everpsblog\Service\AdminRouteSigner:
     class: PrestaShop\Module\Everpsblog\Service\AdminRouteSigner
 


### PR DESCRIPTION
### Motivation
- Symfony autowiring failed when instantiating `PrestaShop\Module\Everpsblog\Controller\Admin\PostController` because the constructor type-hint `PrestaShop\Module\Everpsblog\Service\ImageUploader` had no class-based service id or alias, while the concrete service existed under the custom id `prestashop.module.everpsblog.blog.image_uploader`.

### Description
- Added a class-based service alias in `config/services.yml` mapping `PrestaShop\Module\Everpsblog\Service\ImageUploader` to the existing `prestashop.module.everpsblog.blog.image_uploader` service so autowiring by class name resolves correctly.
- No other functional changes were made; only three lines were inserted in `config/services.yml` to create the alias.

### Testing
- Applied the patch and committed the change successfully (`Add ImageUploader service alias for autowiring`).
- Ran `git diff --check` which reported no issues, and `git status --short` to verify the working tree state, both succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e243d6be888322957f9ed222836382)