### PR TITLE
Fix inconsistent multilingual SEO blocks in backoffice editor

### DIFF
--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -208,7 +208,9 @@
     <div class="tab-pane fade" id="ever-pane-seo" role="tabpanel">
       {% for field in everBlogSections.seo %}
         {% set fieldName = field.vars.name %}
-        <div class="ever-seo-field {% if fieldName starts with 'meta_title_' %}ever-meta-title{% elseif fieldName starts with 'meta_description_' %}ever-meta-description{% elseif fieldName starts with 'link_rewrite_' %}ever-slug-field{% endif %}">
+        {% set fieldLangParts = fieldName|split('_') %}
+        {% set fieldLangId = fieldLangParts|last matches '/^\d+$/' ? fieldLangParts|last : null %}
+        <div class="ever-seo-field {% if fieldName starts with 'meta_title_' %}ever-meta-title{% elseif fieldName starts with 'meta_description_' %}ever-meta-description{% elseif fieldName starts with 'link_rewrite_' %}ever-slug-field{% endif %}"{% if fieldLangId %} data-lang-id="{{ fieldLangId }}"{% endif %}>
           {{ form_row(field) }}
           {% if fieldName starts with 'meta_title_' %}
             <small class="form-text text-muted">
@@ -465,6 +467,7 @@
       var langSwitchers = root.querySelectorAll('.ever-lang-switch');
       var langErrorItems = root.querySelectorAll('.ever-lang-error-item');
       var fieldsWithLang = root.querySelectorAll('[name]');
+      var seoFieldBlocks = root.querySelectorAll('.ever-seo-field[data-lang-id]');
 
       function setActiveLang(langId) {
         Array.prototype.forEach.call(langSwitchers, function (btn) {
@@ -479,6 +482,10 @@
           }
 
           wrapper.style.display = lang === langId ? '' : 'none';
+        });
+
+        Array.prototype.forEach.call(seoFieldBlocks, function (block) {
+          block.style.display = block.getAttribute('data-lang-id') === langId ? '' : 'none';
         });
       }
 


### PR DESCRIPTION
### Motivation
- The SEO tab displayed helper blocks (character counters and slug buttons) for all languages even when the related input rows were hidden, creating empty or duplicated-looking sections during multilingual editing. 
- The goal is to make the SEO UI consistent with the per-input language visibility so only the active language's SEO block is shown.

### Description
- Add language metadata to SEO containers by parsing the field name and setting `data-lang-id` on each `.ever-seo-field` in `views/templates/admin/modern/form.html.twig`.
- Collect `.ever-seo-field[data-lang-id]` nodes in the admin form script and toggle their `style.display` inside `setActiveLang` based on the selected language. 
- Preserve the existing per-input wrapper visibility logic so non-SEO fields keep their prior behavior.

### Testing
- Ran automated check `git diff --check` which produced no errors.
- Ran repository status checks to confirm the modified template is present and staged for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2468859588322b01fff81d27908a2)