### PR TITLE
Align admin BO forms with persisted category/tag/author fields

### DIFF
--- a/src/Application/Blog/AuthorCommandAssembler.php
+++ b/src/Application/Blog/AuthorCommandAssembler.php
@@ -42,10 +42,15 @@ class AuthorCommandAssembler
             'bio' => '',
             'meta_title' => '',
             'meta_description' => '',
+            'twitter' => '',
+            'facebook' => '',
+            'linkedin' => '',
             'active' => 1,
             'indexable' => 1,
             'follow' => 1,
             'sitemap' => 1,
+            'allowed_groups' => [],
+            'author_products' => [],
         ], $data);
     }
 }

--- a/src/Application/Blog/CategoryCommandAssembler.php
+++ b/src/Application/Blog/CategoryCommandAssembler.php
@@ -48,6 +48,8 @@ class CategoryCommandAssembler
             'sitemap' => 1,
             'id_parent_category' => null,
             'is_root_category' => 0,
+            'allowed_groups' => [],
+            'category_products' => [],
         ], $data);
     }
 }

--- a/src/Application/Blog/TagCommandAssembler.php
+++ b/src/Application/Blog/TagCommandAssembler.php
@@ -46,6 +46,8 @@ class TagCommandAssembler
             'indexable' => 1,
             'follow' => 1,
             'sitemap' => 1,
+            'allowed_groups' => [],
+            'tag_products' => [],
         ], $data);
     }
 }

--- a/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/AuthorWriteRepository.php
@@ -22,11 +22,15 @@ class AuthorWriteRepository
             'id_employee' => (int) $data['id_employee'],
             'id_shop' => (int) $data['id_shop'],
             'nickhandle' => (string) $data['nickhandle'],
+            'twitter' => (string) ($data['twitter'] ?? ''),
+            'facebook' => (string) ($data['facebook'] ?? ''),
+            'linkedin' => (string) ($data['linkedin'] ?? ''),
             'active' => (int) $data['active'],
             'indexable' => (int) $data['indexable'],
             'follow' => (int) $data['follow'],
             'sitemap' => (int) $data['sitemap'],
-            'allowed_groups' => null,
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'author_products' => $this->encodeArray($data['author_products'] ?? null),
             'count' => 0,
         ]);
 
@@ -42,10 +46,15 @@ class AuthorWriteRepository
         $connection->update('ever_blog_author', [
             'id_employee' => (int) $data['id_employee'],
             'nickhandle' => (string) $data['nickhandle'],
+            'twitter' => (string) ($data['twitter'] ?? ''),
+            'facebook' => (string) ($data['facebook'] ?? ''),
+            'linkedin' => (string) ($data['linkedin'] ?? ''),
             'active' => (int) $data['active'],
             'indexable' => (int) $data['indexable'],
             'follow' => (int) $data['follow'],
             'sitemap' => (int) $data['sitemap'],
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'author_products' => $this->encodeArray($data['author_products'] ?? null),
         ], ['id_ever_author' => $authorId]);
 
         $this->replaceRelations($authorId, $data);
@@ -83,5 +92,17 @@ class AuthorWriteRepository
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? ''),
             ]);
         }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encodeArray($value): ?string
+    {
+        if (!is_array($value) || empty($value)) {
+            return null;
+        }
+
+        return json_encode(array_values(array_map('intval', $value)));
     }
 }

--- a/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/CategoryWriteRepository.php
@@ -28,8 +28,9 @@ class CategoryWriteRepository
             'sitemap' => (int) $data['sitemap'],
             'is_root_category' => (int) $data['is_root_category'],
             'count' => 0,
-            'allowed_groups' => null,
-            'groups' => null,
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'category_products' => $this->encodeArray($data['category_products'] ?? null),
+            'groups' => $this->encodeArray($data['allowed_groups'] ?? null),
             'date_add' => $now,
             'date_upd' => $now,
         ]);
@@ -49,6 +50,10 @@ class CategoryWriteRepository
             'indexable' => (int) $data['indexable'],
             'follow' => (int) $data['follow'],
             'sitemap' => (int) $data['sitemap'],
+            'is_root_category' => (int) ($data['is_root_category'] ?? 0),
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'category_products' => $this->encodeArray($data['category_products'] ?? null),
+            'groups' => $this->encodeArray($data['allowed_groups'] ?? null),
             'date_upd' => date('Y-m-d H:i:s'),
         ], ['id_ever_category' => $categoryId]);
 
@@ -88,5 +93,17 @@ class CategoryWriteRepository
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
             ]);
         }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encodeArray($value): ?string
+    {
+        if (!is_array($value) || empty($value)) {
+            return null;
+        }
+
+        return json_encode(array_values(array_map('intval', $value)));
     }
 }

--- a/src/Core/Domain/Blog/Repository/TagWriteRepository.php
+++ b/src/Core/Domain/Blog/Repository/TagWriteRepository.php
@@ -24,7 +24,8 @@ class TagWriteRepository
             'indexable' => (int) $data['indexable'],
             'follow' => (int) $data['follow'],
             'sitemap' => (int) $data['sitemap'],
-            'allowed_groups' => null,
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'tag_products' => $this->encodeArray($data['tag_products'] ?? null),
             'count' => 0,
         ]);
 
@@ -42,6 +43,8 @@ class TagWriteRepository
             'indexable' => (int) $data['indexable'],
             'follow' => (int) $data['follow'],
             'sitemap' => (int) $data['sitemap'],
+            'allowed_groups' => $this->encodeArray($data['allowed_groups'] ?? null),
+            'tag_products' => $this->encodeArray($data['tag_products'] ?? null),
         ], ['id_ever_tag' => $tagId]);
 
         $this->replaceRelations($tagId, $data);
@@ -80,5 +83,17 @@ class TagWriteRepository
                 'bottom_content' => (string) ($data['bottom_content_' . $langId] ?? $data['bottom_content']),
             ]);
         }
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function encodeArray($value): ?string
+    {
+        if (!is_array($value) || empty($value)) {
+            return null;
+        }
+
+        return json_encode(array_values(array_map('intval', $value)));
     }
 }

--- a/src/Form/DataProvider/AuthorFormDataProvider.php
+++ b/src/Form/DataProvider/AuthorFormDataProvider.php
@@ -48,6 +48,12 @@ final class AuthorFormDataProvider
             'indexable' => (bool) ($author['indexable'] ?? 0),
             'follow' => (bool) ($author['follow'] ?? 0),
             'sitemap' => (bool) ($author['sitemap'] ?? 0),
+            'twitter' => (string) ($author['twitter'] ?? ''),
+            'facebook' => (string) ($author['facebook'] ?? ''),
+            'linkedin' => (string) ($author['linkedin'] ?? ''),
+            'count' => (int) ($author['count'] ?? 0),
+            'allowed_groups' => $this->normalizeIntCollection($author['allowed_groups'] ?? null),
+            'author_products' => $this->normalizeIntCollection($author['author_products'] ?? null),
             'bio' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -107,6 +113,12 @@ final class AuthorFormDataProvider
             'indexable' => true,
             'follow' => true,
             'sitemap' => true,
+            'twitter' => '',
+            'facebook' => '',
+            'linkedin' => '',
+            'count' => 0,
+            'allowed_groups' => [],
+            'author_products' => [],
             'bio' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -126,5 +138,32 @@ final class AuthorFormDataProvider
         }
 
         return $data;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int[]
+     */
+    private function normalizeIntCollection($value): array
+    {
+        if (null === $value || '' === $value) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            return array_values(array_map('intval', $value));
+        }
+
+        $decoded = json_decode((string) $value, true);
+        if (is_array($decoded)) {
+            return array_values(array_map('intval', $decoded));
+        }
+
+        $items = array_filter(array_map('trim', explode(',', (string) $value)), static function ($item) {
+            return '' !== $item;
+        });
+
+        return array_values(array_map('intval', $items));
     }
 }

--- a/src/Form/DataProvider/CategoryFormDataProvider.php
+++ b/src/Form/DataProvider/CategoryFormDataProvider.php
@@ -48,6 +48,9 @@ final class CategoryFormDataProvider
             'follow' => (bool) ($category['follow'] ?? 0),
             'sitemap' => (bool) ($category['sitemap'] ?? 0),
             'is_root_category' => (bool) ($category['is_root_category'] ?? 0),
+            'count' => (int) ($category['count'] ?? 0),
+            'allowed_groups' => $this->normalizeIntCollection($category['allowed_groups'] ?? null),
+            'category_products' => $this->normalizeIntCollection($category['category_products'] ?? null),
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -107,6 +110,9 @@ final class CategoryFormDataProvider
             'follow' => true,
             'sitemap' => true,
             'is_root_category' => false,
+            'count' => 0,
+            'allowed_groups' => [],
+            'category_products' => [],
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -126,5 +132,32 @@ final class CategoryFormDataProvider
         }
 
         return $data;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int[]
+     */
+    private function normalizeIntCollection($value): array
+    {
+        if (null === $value || '' === $value) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            return array_values(array_map('intval', $value));
+        }
+
+        $decoded = json_decode((string) $value, true);
+        if (is_array($decoded)) {
+            return array_values(array_map('intval', $decoded));
+        }
+
+        $items = array_filter(array_map('trim', explode(',', (string) $value)), static function ($item) {
+            return '' !== $item;
+        });
+
+        return array_values(array_map('intval', $items));
     }
 }

--- a/src/Form/DataProvider/TagFormDataProvider.php
+++ b/src/Form/DataProvider/TagFormDataProvider.php
@@ -45,6 +45,9 @@ final class TagFormDataProvider
             'indexable' => (bool) ($tag['indexable'] ?? 0),
             'follow' => (bool) ($tag['follow'] ?? 0),
             'sitemap' => (bool) ($tag['sitemap'] ?? 0),
+            'count' => (int) ($tag['count'] ?? 0),
+            'allowed_groups' => $this->normalizeIntCollection($tag['allowed_groups'] ?? null),
+            'tag_products' => $this->normalizeIntCollection($tag['tag_products'] ?? null),
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -102,6 +105,9 @@ final class TagFormDataProvider
             'indexable' => true,
             'follow' => true,
             'sitemap' => true,
+            'count' => 0,
+            'allowed_groups' => [],
+            'tag_products' => [],
             'title' => '',
             'meta_title' => '',
             'meta_description' => '',
@@ -121,5 +127,32 @@ final class TagFormDataProvider
         }
 
         return $data;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return int[]
+     */
+    private function normalizeIntCollection($value): array
+    {
+        if (null === $value || '' === $value) {
+            return [];
+        }
+
+        if (is_array($value)) {
+            return array_values(array_map('intval', $value));
+        }
+
+        $decoded = json_decode((string) $value, true);
+        if (is_array($decoded)) {
+            return array_values(array_map('intval', $decoded));
+        }
+
+        $items = array_filter(array_map('trim', explode(',', (string) $value)), static function ($item) {
+            return '' !== $item;
+        });
+
+        return array_values(array_map('intval', $items));
     }
 }

--- a/src/Form/Type/Admin/AuthorType.php
+++ b/src/Form/Type/Admin/AuthorType.php
@@ -3,6 +3,9 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,11 +20,70 @@ final class AuthorType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        $builder->add('nickhandle', TextType::class, [
-            'required' => false,
-            'label' => 'Pseudo',
-            'constraints' => [new Length(['max' => 255])],
-        ]);
+        $builder
+            ->add('id_employee', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Employé lié',
+                'placeholder' => 'Aucun employé lié',
+                'choices' => $this->getEmployeeChoices(),
+            ])
+            ->add('nickhandle', TextType::class, [
+                'required' => false,
+                'label' => 'Pseudo',
+                'constraints' => [new Length(['max' => 255])],
+            ])
+            ->add('twitter', TextType::class, [
+                'required' => false,
+                'label' => 'Twitter',
+                'constraints' => [new Length(['max' => 255])],
+            ])
+            ->add('facebook', TextType::class, [
+                'required' => false,
+                'label' => 'Facebook',
+                'constraints' => [new Length(['max' => 255])],
+            ])
+            ->add('linkedin', TextType::class, [
+                'required' => false,
+                'label' => 'LinkedIn',
+                'constraints' => [new Length(['max' => 255])],
+            ])
+            ->add('active', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Actif',
+            ])
+            ->add('indexable', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Indexable',
+            ])
+            ->add('follow', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Follow',
+            ])
+            ->add('sitemap', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Inclure dans le sitemap',
+            ])
+            ->add('count', IntegerType::class, [
+                'required' => false,
+                'label' => 'Compteur',
+                'disabled' => true,
+            ])
+            ->add('allowed_groups', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Groupes autorisés',
+                'choices' => $this->getGroupChoices(),
+                'multiple' => true,
+                'expanded' => true,
+            ])
+            ->add('author_products', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Produits liés',
+                'choices' => $this->getProductChoices(),
+                'multiple' => true,
+                'expanded' => false,
+                'attr' => ['data-ever-tagify' => '1'],
+            ])
+        ;
 
         foreach (\Language::getLanguages(false) as $lang) {
             $idLang = (int) $lang['id_lang'];
@@ -60,5 +122,78 @@ final class AuthorType extends AbstractType
                 ])
             ;
         }
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getEmployeeChoices(): array
+    {
+        $rows = \Db::getInstance()->executeS(
+            'SELECT e.id_employee, CONCAT(COALESCE(e.firstname, \'\'), \' \', COALESCE(e.lastname, \'\')) AS fullname
+            FROM `' . _DB_PREFIX_ . 'employee` e
+            ORDER BY e.id_employee DESC'
+        ) ?: [];
+
+        $choices = [];
+        foreach ($rows as $row) {
+            $id = (int) ($row['id_employee'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($row['fullname'] ?? ''));
+            $choices[$label ?: sprintf('Employé #%d', $id)] = $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getProductChoices(): array
+    {
+        $rows = \Db::getInstance()->executeS(
+            'SELECT p.id_product, pl.name
+            FROM `' . _DB_PREFIX_ . 'product` p
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.id_product = p.id_product AND pl.id_lang = ' . (int) \Context::getContext()->language->id . ' AND pl.id_shop = ' . (int) \Context::getContext()->shop->id . ')
+            ORDER BY p.id_product DESC
+            LIMIT 500'
+        ) ?: [];
+
+        $choices = [];
+        foreach ($rows as $row) {
+            $id = (int) ($row['id_product'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($row['name'] ?? ''));
+            $choices[$label ?: sprintf('Produit #%d', $id)] = $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getGroupChoices(): array
+    {
+        $groups = \Group::getGroups((int) \Context::getContext()->language->id) ?: [];
+        $choices = [];
+
+        foreach ($groups as $group) {
+            $id = (int) ($group['id_group'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($group['name'] ?? ''));
+            $choices[$label ?: sprintf('Groupe #%d', $id)] = $id;
+        }
+
+        return $choices;
     }
 }

--- a/src/Form/Type/Admin/CategoryType.php
+++ b/src/Form/Type/Admin/CategoryType.php
@@ -3,6 +3,9 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,6 +20,55 @@ final class CategoryType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder
+            ->add('id_parent_category', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Catégorie parente',
+                'placeholder' => 'Aucune (racine)',
+                'choices' => $this->getParentCategoryChoices(),
+            ])
+            ->add('is_root_category', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Catégorie racine',
+            ])
+            ->add('active', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Active',
+            ])
+            ->add('indexable', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Indexable',
+            ])
+            ->add('follow', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Follow',
+            ])
+            ->add('sitemap', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Inclure dans le sitemap',
+            ])
+            ->add('count', IntegerType::class, [
+                'required' => false,
+                'label' => 'Compteur',
+                'disabled' => true,
+            ])
+            ->add('allowed_groups', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Groupes autorisés',
+                'choices' => $this->getGroupChoices(),
+                'multiple' => true,
+                'expanded' => true,
+            ])
+            ->add('category_products', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Produits liés',
+                'choices' => $this->getProductChoices(),
+                'multiple' => true,
+                'expanded' => false,
+                'attr' => ['data-ever-tagify' => '1'],
+            ])
+        ;
+
         foreach (\Language::getLanguages(false) as $lang) {
             $idLang = (int) $lang['id_lang'];
             $isoCode = strtoupper((string) ($lang['iso_code'] ?? ''));
@@ -59,5 +111,79 @@ final class CategoryType extends AbstractType
                 ])
             ;
         }
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getParentCategoryChoices(): array
+    {
+        $rows = \Db::getInstance()->executeS(
+            'SELECT c.id_ever_category, cl.title
+            FROM `' . _DB_PREFIX_ . 'ever_blog_category` c
+            LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_category_lang` cl ON (cl.id_ever_category = c.id_ever_category AND cl.id_lang = ' . (int) \Context::getContext()->language->id . ')
+            ORDER BY c.id_ever_category ASC'
+        ) ?: [];
+
+        $choices = [];
+        foreach ($rows as $row) {
+            $id = (int) ($row['id_ever_category'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($row['title'] ?? ''));
+            $choices[$label ?: sprintf('Catégorie #%d', $id)] = $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getProductChoices(): array
+    {
+        $rows = \Db::getInstance()->executeS(
+            'SELECT p.id_product, pl.name
+            FROM `' . _DB_PREFIX_ . 'product` p
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.id_product = p.id_product AND pl.id_lang = ' . (int) \Context::getContext()->language->id . ' AND pl.id_shop = ' . (int) \Context::getContext()->shop->id . ')
+            ORDER BY p.id_product DESC
+            LIMIT 500'
+        ) ?: [];
+
+        $choices = [];
+        foreach ($rows as $row) {
+            $id = (int) ($row['id_product'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($row['name'] ?? ''));
+            $choices[$label ?: sprintf('Produit #%d', $id)] = $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getGroupChoices(): array
+    {
+        $groups = \Group::getGroups((int) \Context::getContext()->language->id) ?: [];
+        $choices = [];
+
+        foreach ($groups as $group) {
+            $id = (int) ($group['id_group'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($group['name'] ?? ''));
+            $choices[$label ?: sprintf('Groupe #%d', $id)] = $id;
+        }
+
+        return $choices;
     }
 }

--- a/src/Form/Type/Admin/TagType.php
+++ b/src/Form/Type/Admin/TagType.php
@@ -3,6 +3,9 @@
 namespace PrestaShop\Module\Everpsblog\Form\Type\Admin;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -17,6 +20,45 @@ final class TagType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $builder
+            ->add('active', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Actif',
+            ])
+            ->add('indexable', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Indexable',
+            ])
+            ->add('follow', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Follow',
+            ])
+            ->add('sitemap', CheckboxType::class, [
+                'required' => false,
+                'label' => 'Inclure dans le sitemap',
+            ])
+            ->add('count', IntegerType::class, [
+                'required' => false,
+                'label' => 'Compteur',
+                'disabled' => true,
+            ])
+            ->add('allowed_groups', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Groupes autorisés',
+                'choices' => $this->getGroupChoices(),
+                'multiple' => true,
+                'expanded' => true,
+            ])
+            ->add('tag_products', ChoiceType::class, [
+                'required' => false,
+                'label' => 'Produits liés',
+                'choices' => $this->getProductChoices(),
+                'multiple' => true,
+                'expanded' => false,
+                'attr' => ['data-ever-tagify' => '1'],
+            ])
+        ;
+
         foreach (\Language::getLanguages(false) as $lang) {
             $idLang = (int) $lang['id_lang'];
             $isoCode = strtoupper((string) ($lang['iso_code'] ?? ''));
@@ -59,5 +101,53 @@ final class TagType extends AbstractType
                 ])
             ;
         }
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getProductChoices(): array
+    {
+        $rows = \Db::getInstance()->executeS(
+            'SELECT p.id_product, pl.name
+            FROM `' . _DB_PREFIX_ . 'product` p
+            LEFT JOIN `' . _DB_PREFIX_ . 'product_lang` pl ON (pl.id_product = p.id_product AND pl.id_lang = ' . (int) \Context::getContext()->language->id . ' AND pl.id_shop = ' . (int) \Context::getContext()->shop->id . ')
+            ORDER BY p.id_product DESC
+            LIMIT 500'
+        ) ?: [];
+
+        $choices = [];
+        foreach ($rows as $row) {
+            $id = (int) ($row['id_product'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($row['name'] ?? ''));
+            $choices[$label ?: sprintf('Produit #%d', $id)] = $id;
+        }
+
+        return $choices;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function getGroupChoices(): array
+    {
+        $groups = \Group::getGroups((int) \Context::getContext()->language->id) ?: [];
+        $choices = [];
+
+        foreach ($groups as $group) {
+            $id = (int) ($group['id_group'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $label = trim((string) ($group['name'] ?? ''));
+            $choices[$label ?: sprintf('Groupe #%d', $id)] = $id;
+        }
+
+        return $choices;
     }
 }

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -299,9 +299,9 @@
         {% set contentFields = contentFields|merge([child]) %}
       {% elseif fieldName starts with 'meta_title_' or fieldName starts with 'meta_description_' or fieldName starts with 'link_rewrite_' %}
         {% set seoFields = seoFields|merge([child]) %}
-      {% elseif fieldName in ['post_status', 'date_add', 'id_author', 'starred', 'psswd'] %}
+      {% elseif fieldName in ['post_status', 'date_add', 'id_author', 'starred', 'psswd', 'active', 'indexable', 'follow', 'sitemap', 'id_parent_category', 'is_root_category', 'id_employee', 'twitter', 'facebook', 'linkedin', 'count'] %}
         {% set publicationFields = publicationFields|merge([child]) %}
-      {% elseif fieldName in ['id_default_category', 'post_categories', 'post_tags', 'post_products', 'allowed_groups'] %}
+      {% elseif fieldName in ['id_default_category', 'post_categories', 'post_tags', 'post_products', 'allowed_groups', 'category_products', 'tag_products', 'author_products'] %}
         {% set relationFields = relationFields|merge([child]) %}
       {% else %}
         {% set otherFields = otherFields|merge([child]) %}


### PR DESCRIPTION
### Motivation
- The back-office forms did not expose several fields that are actually stored in the database, creating a gap between what can be edited in the BO and what exists in the DB.

### Description
- Expose DB-backed fields on admin forms by extending `CategoryType`, `TagType` and `AuthorType` with publication flags, parent/root config, readonly counters, allowed groups, linked products, employee/social metadata and related choice providers.
- Populate those fields in the form UI by updating `CategoryFormDataProvider`, `TagFormDataProvider` and `AuthorFormDataProvider` to read existing rows and normalize legacy JSON/CSV arrays into integer ID arrays.
- Persist these fields on create/update by updating `CategoryWriteRepository`, `TagWriteRepository` and `AuthorWriteRepository` and adding `encodeArray` helpers to serialize arrays for legacy columns.
- Add sane defaults for the new fields in `CategoryCommandAssembler`, `TagCommandAssembler` and `AuthorCommandAssembler` and update the admin form template `views/templates/admin/modern/form.html.twig` to place new fields into `publication` and `relations` sections.

### Testing
- Performed syntax checks with `php -l` on all modified PHP files under `src/Form`, `src/Form/DataProvider`, `src/Core/Domain/Blog/Repository` and `src/Application/Blog`, and no syntax errors were reported.
- All automated checks executed in this environment completed successfully (no runtime or lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e245abe24083228a9ba5bd573e3e73)