### PR TITLE
Restore legacy EverPsBlog helpers and fix post status SQL

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -20,6 +20,9 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/everpsblogpost.php';
+require_once __DIR__ . '/everpsblogcategory.php';
+require_once __DIR__ . '/everpsblogtag.php';
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
 use PrestaShop\PrestaShop\Adapter\Product\PriceFormatter;
 use PrestaShop\PrestaShop\Core\Product\ProductListingPresenter;
@@ -252,7 +255,7 @@ class EverPsBlog extends Module
         $sql->innerJoin('ever_blog_post_lang', 'pl', 'pl.id_ever_post = p.id_ever_post AND pl.id_lang = ' . (int) $idLang);
         $sql->innerJoin('ever_blog_post_shop', 'ps', 'ps.id_ever_post = p.id_ever_post AND ps.id_shop = ' . (int) $idShop);
         $sql->leftJoin('ever_blog_category_lang', 'dcl', 'dcl.id_ever_category = p.id_default_category AND dcl.id_lang = ' . (int) $idLang);
-        $sql->where('p.status = "published"');
+        $sql->where('p.post_status = "published"');
         $sql->where('p.starred = 1');
         $sql->orderBy('p.created_at DESC, p.id_ever_post DESC');
         $sql->limit((int) $limit);

--- a/everpsblogcategory.php
+++ b/everpsblogcategory.php
@@ -1,0 +1,29 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverPsBlogCategory
+{
+    public static function getAllCategories($idLang, $idShop, $active = true, $idParent = null)
+    {
+        $sql = new DbQuery();
+        $sql->select('c.id_ever_category, c.is_root_category, cl.title, cl.link_rewrite');
+        $sql->from('ever_blog_category', 'c');
+        $sql->innerJoin('ever_blog_category_lang', 'cl', 'cl.id_ever_category = c.id_ever_category AND cl.id_lang = ' . (int) $idLang);
+        $sql->innerJoin('ever_blog_category_shop', 'cs', 'cs.id_ever_category = c.id_ever_category AND cs.id_shop = ' . (int) $idShop);
+
+        if ($active) {
+            $sql->where('c.active = 1');
+        }
+
+        if (null !== $idParent) {
+            $sql->where('c.id_parent_category = ' . (int) $idParent);
+        }
+
+        $sql->orderBy('cl.title ASC');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql) ?: [];
+    }
+}

--- a/everpsblogpost.php
+++ b/everpsblogpost.php
@@ -1,0 +1,106 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverPsBlogPost
+{
+    public $id;
+    public $id_ever_post;
+
+    public function __construct($idEverPost = null, $idLang = null, $idShop = null)
+    {
+        if (!$idEverPost) {
+            return;
+        }
+
+        $idLang = (int) ($idLang ?: Context::getContext()->language->id);
+        $idShop = (int) ($idShop ?: Context::getContext()->shop->id);
+
+        $row = self::getSinglePost((int) $idEverPost, $idLang, $idShop);
+        if (!$row) {
+            return;
+        }
+
+        foreach ($row as $key => $value) {
+            $this->{$key} = $value;
+        }
+
+        $this->id_ever_post = (int) $idEverPost;
+        $this->id = (int) $idEverPost;
+    }
+
+    public static function countPosts($idLang, $idShop, $status = 'published')
+    {
+        $sql = new DbQuery();
+        $sql->select('COUNT(DISTINCT p.id_ever_post)');
+        $sql->from('ever_blog_post', 'p');
+        $sql->innerJoin('ever_blog_post_lang', 'pl', 'pl.id_ever_post = p.id_ever_post AND pl.id_lang = ' . (int) $idLang);
+        $sql->innerJoin('ever_blog_post_shop', 'ps', 'ps.id_ever_post = p.id_ever_post AND ps.id_shop = ' . (int) $idShop);
+        $sql->where('p.active = 1');
+
+        if (null !== $status) {
+            $sql->where('p.post_status = "' . pSQL((string) $status) . '"');
+        }
+
+        return (int) Db::getInstance(_PS_USE_SQL_SLAVE_)->getValue($sql);
+    }
+
+    public static function getPosts($idLang, $idShop, $start = 0, $limit = null, $status = 'published', $active = true, $starred = false, $orderBy = null, $orderWay = null)
+    {
+        $sql = new DbQuery();
+        $sql->select('p.id_ever_post, p.id_author as id_ever_author, p.date_add, p.starred as is_featured, p.post_status, p.active, p.count as view_count, pl.title, pl.link_rewrite, pl.meta_title, pl.meta_description, pl.excerpt, pl.content, a.nickhandle');
+        $sql->from('ever_blog_post', 'p');
+        $sql->innerJoin('ever_blog_post_lang', 'pl', 'pl.id_ever_post = p.id_ever_post AND pl.id_lang = ' . (int) $idLang);
+        $sql->innerJoin('ever_blog_post_shop', 'ps', 'ps.id_ever_post = p.id_ever_post AND ps.id_shop = ' . (int) $idShop);
+        $sql->leftJoin('ever_blog_author', 'a', 'a.id_ever_author = p.id_author');
+
+        if ($active) {
+            $sql->where('p.active = 1');
+        }
+
+        if (null !== $status) {
+            $sql->where('p.post_status = "' . pSQL((string) $status) . '"');
+        }
+
+        if ($starred) {
+            $sql->where('p.starred = 1');
+        }
+
+        $allowedOrderBy = ['date_add', 'title', 'id_ever_post'];
+        $allowedOrderWay = ['ASC', 'DESC'];
+        $orderBy = in_array($orderBy, $allowedOrderBy, true) ? $orderBy : 'date_add';
+        $orderWay = in_array(strtoupper((string) $orderWay), $allowedOrderWay, true) ? strtoupper((string) $orderWay) : 'DESC';
+
+        if ('title' === $orderBy) {
+            $sql->orderBy('pl.title ' . $orderWay . ', p.id_ever_post DESC');
+        } elseif ('id_ever_post' === $orderBy) {
+            $sql->orderBy('p.id_ever_post ' . $orderWay);
+        } else {
+            $sql->orderBy('p.date_add ' . $orderWay . ', p.id_ever_post DESC');
+        }
+
+        if (null !== $limit) {
+            $sql->limit((int) $limit, (int) $start);
+        } elseif ((int) $start > 0) {
+            $sql->limit(18446744073709551615, (int) $start);
+        }
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql) ?: [];
+    }
+
+    private static function getSinglePost($idEverPost, $idLang, $idShop)
+    {
+        $sql = new DbQuery();
+        $sql->select('p.id_ever_post, p.id_author as id_ever_author, p.date_add, p.starred as is_featured, p.post_status, p.active, p.count as view_count, pl.title, pl.link_rewrite, pl.meta_title, pl.meta_description, pl.excerpt, pl.content, a.nickhandle');
+        $sql->from('ever_blog_post', 'p');
+        $sql->innerJoin('ever_blog_post_lang', 'pl', 'pl.id_ever_post = p.id_ever_post AND pl.id_lang = ' . (int) $idLang);
+        $sql->innerJoin('ever_blog_post_shop', 'ps', 'ps.id_ever_post = p.id_ever_post AND ps.id_shop = ' . (int) $idShop);
+        $sql->leftJoin('ever_blog_author', 'a', 'a.id_ever_author = p.id_author');
+        $sql->where('p.id_ever_post = ' . (int) $idEverPost);
+        $sql->limit(1);
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->getRow($sql);
+    }
+}

--- a/everpsblogtag.php
+++ b/everpsblogtag.php
@@ -1,0 +1,25 @@
+<?php
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class EverPsBlogTag
+{
+    public static function getAllTags($idLang, $idShop, $active = true)
+    {
+        $sql = new DbQuery();
+        $sql->select('t.id_ever_tag, tl.title, tl.link_rewrite');
+        $sql->from('ever_blog_tag', 't');
+        $sql->innerJoin('ever_blog_tag_lang', 'tl', 'tl.id_ever_tag = t.id_ever_tag AND tl.id_lang = ' . (int) $idLang);
+        $sql->innerJoin('ever_blog_tag_shop', 'ts', 'ts.id_ever_tag = t.id_ever_tag AND ts.id_shop = ' . (int) $idShop);
+
+        if ($active) {
+            $sql->where('t.active = 1');
+        }
+
+        $sql->orderBy('tl.title ASC');
+
+        return Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql) ?: [];
+    }
+}


### PR DESCRIPTION
### Motivation
- Frontend code still depends on legacy `EverPsBlog*` classes and a manual SQL used `p.status` which no longer exists, causing runtime fatals like `Class "EverPsBlogPost" not found` and `Unknown column 'p.status'`.

### Description
- Replace the incorrect SQL predicate `p.status = "published"` with `p.post_status = "published"` in `getStarredPostsForHome` inside `everpsblog.php`.
- Add lightweight legacy compatibility classes in new files: `everpsblogpost.php` (class `EverPsBlogPost` with constructor hydration, `countPosts`, `getPosts`, and helper `getSinglePost`), `everpsblogcategory.php` (class `EverPsBlogCategory::getAllCategories`), and `everpsblogtag.php` (class `EverPsBlogTag::getAllTags`).
- Wire the compatibility files into the module bootstrap by adding `require_once` entries for the three new files in `everpsblog.php` so legacy front controllers can resolve class references at runtime.

### Testing
- Ran syntax checks `php -l everpsblog.php`, `php -l everpsblogpost.php`, `php -l everpsblogcategory.php`, and `php -l everpsblogtag.php`, all of which reported no syntax errors.
- Committed the changes after validation and verified the modified lines were applied (`everpsblog.php` require additions and SQL fix plus three new legacy helper files were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2492376cc8322bce38110352d3ab1)