### PR TITLE
Fix front service resolution and planned post publishing fallback

### DIFF
--- a/controllers/front/author.php
+++ b/controllers/front/author.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\AuthorController;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\PostViewModel;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\TaxonomyViewModel;
@@ -255,17 +254,17 @@ class EverPsBlogauthorModuleFrontController extends AuthorController
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/controllers/front/blog.php
+++ b/controllers/front/blog.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\AbstractFrontController;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\PostViewModel;
 
@@ -337,17 +336,17 @@ class EverPsBlogblogModuleFrontController extends AbstractFrontController
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\CategoryController;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\PostViewModel;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\TaxonomyViewModel;
@@ -285,17 +284,17 @@ class EverPsBlogcategoryModuleFrontController extends CategoryController
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/controllers/front/customercomments.php
+++ b/controllers/front/customercomments.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\CustomerCommentsController;
 
 use PrestaShop\PrestaShop\Adapter\Image\ImageRetriever;
@@ -132,17 +131,17 @@ class EverPsBlogcustomercommentsModuleFrontController extends CustomerCommentsCo
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\PostController;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\PostViewModel;
 
@@ -626,17 +625,17 @@ class EverPsBlogpostModuleFrontController extends PostController
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/controllers/front/tag.php
+++ b/controllers/front/tag.php
@@ -21,7 +21,6 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 use PrestaShop\Module\Everpsblog\Controller\Front\TagController;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\PostViewModel;
 use PrestaShop\Module\Everpsblog\ViewModel\Front\TaxonomyViewModel;
@@ -232,17 +231,17 @@ class EverPsBlogtagModuleFrontController extends TagController
 
     private function getBlogImageService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_image');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
     }
 
     private function getBlogTaxonomyService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_taxonomy');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
     }
 
     private function getBlogSortOrderService()
     {
-        return SymfonyContainer::getInstance()->get('prestashop.module.everpsblog.service.blog_sort_order');
+        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
     }
 
 }

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -2693,28 +2693,28 @@ class EverPsBlog extends Module
 
     public function publishPlannedPosts($id_shop)
     {
-        $context = Context::getContext();
-        $posts = EverPsBlogPost::getPosts(
-            (int) $context->language->id,
-            (int) $id_shop,
-            0,
-            0,
-            'planned'
-        );
-        if (!count($posts)) {
+        $sql = new DbQuery();
+        $sql->select('p.id_ever_post');
+        $sql->from('ever_blog_post', 'p');
+        $sql->innerJoin('ever_blog_post_shop', 'ps', 'ps.id_ever_post = p.id_ever_post AND ps.id_shop = ' . (int) $id_shop);
+        $sql->where('p.post_status = "planned"');
+        $sql->where('p.date_add <= "' . pSQL(date('Y-m-d H:i:s')) . '"');
+
+        $posts = Db::getInstance()->executeS($sql) ?: [];
+        if (!$posts) {
             return;
         }
+
         foreach ($posts as $planned) {
-            $post = new EverPsBlogPost(
-                (int) $planned['id_ever_post'],
-                (int) $context->language->id,
-                (int) $id_shop
+            Db::getInstance()->update(
+                'ever_blog_post',
+                [
+                    'post_status' => 'published',
+                ],
+                'id_ever_post = ' . (int) $planned['id_ever_post']
             );
-            if ($post->date_add <= date('Y-m-d H:i:s')) {
-                $post->post_status = 'published';
-                $post->save();
-            }
         }
+
         return true;
     }
 

--- a/src/Controller/Front/AbstractFrontController.php
+++ b/src/Controller/Front/AbstractFrontController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Everpsblog\Controller\Front;
 
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
+use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 require_once dirname(__DIR__, 3) . '/everpsblog.php';
 
@@ -136,6 +137,25 @@ abstract class AbstractFrontController extends \ModuleFrontController
             $idColumn => (int) $row[$idColumn],
             'link_rewrite' => (string) $row['link_rewrite'],
         ];
+    }
+
+
+    protected function getModuleService(string $serviceId)
+    {
+        if (isset($this->module) && method_exists($this->module, 'get')) {
+            try {
+                return $this->module->get($serviceId);
+            } catch (\Throwable $exception) {
+                // Fallback to legacy Symfony container access below.
+            }
+        }
+
+        $container = SymfonyContainer::getInstance();
+        if (null === $container) {
+            throw new \RuntimeException(sprintf('Symfony container is unavailable for service "%s".', $serviceId));
+        }
+
+        return $container->get($serviceId);
     }
 
     protected function getTemplateVarPagination($total = 0)


### PR DESCRIPTION
### Motivation
- Prevent front-office fatals caused by direct access to the Symfony container when it may be unavailable, and avoid relying on a legacy `EverPsBlogPost` class during automated publication of planned posts.
- Ensure cron/CLI/legacy paths that publish planned posts do not fail when the legacy model class is not loaded.

### Description
- Added a resilient helper `getModuleService(string $serviceId)` in `src/Controller/Front/AbstractFrontController.php` that first attempts `$this->module->get($serviceId)` and falls back to the Symfony container when available, throwing a clear `RuntimeException` if no container is accessible.
- Replaced direct calls to `SymfonyContainer::getInstance()->get(...)` in front controllers (`controllers/front/blog.php`, `controllers/front/category.php`, `controllers/front/author.php`, `controllers/front/tag.php`, `controllers/front/post.php`, `controllers/front/customercomments.php`) with calls to the new `getModuleService()` helper for `blog_image`, `blog_taxonomy`, and `blog_sort_order` services.
- Rewrote `publishPlannedPosts()` in `everpsblog.php` to use a `DbQuery` and direct `UPDATE` SQL so planned posts are published without instantiating the legacy `EverPsBlogPost` class.

### Testing
- Ran PHP lint checks with `php -l` on `src/Controller/Front/AbstractFrontController.php`, `controllers/front/blog.php`, `controllers/front/category.php`, `controllers/front/author.php`, `controllers/front/tag.php`, `controllers/front/post.php`, `controllers/front/customercomments.php`, and `everpsblog.php`, and all files returned `No syntax errors detected`.
- No additional automated unit or integration tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e24cd69b748322a9c8be6ec41d2e1a)