### PR TITLE
feat(front): Bootstrap 5 compatibility for front/hook templates

### DIFF
--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -103,7 +103,7 @@
 {if isset($allow_feed) && $allow_feed}
 <a class="rss-link" href="{$feed_url|escape:'htmlall':'UTF-8'}" target="_blank">{l s='RSS feed for' mod='everpsblog'} {$page.meta.title|escape:'htmlall':'UTF-8'}</a>
 {/if}
-<span class="paginated float-end float-right d-none">{if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}</span>
+<span class="paginated float-end d-none">{if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}</span>
 {if isset($paginated) && !$paginated}
 {if isset($default_blog_top_text) && $default_blog_top_text}
 <div class="row mt-2">

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -92,7 +92,7 @@
                         <div class="social-sharing social-sharing-hero">
                             <ul>
                             {foreach from=$social_share_links item='social_share_link'}
-                                <li class="{$social_share_link.class|escape:'htmlall':'UTF-8'} icon-gray"><a href="{$social_share_link.url|escape:'htmlall':'UTF-8'}" class="text-hide" title="{$social_share_link.label|escape:'htmlall':'UTF-8'}" target="_blank">{$social_share_link.label|escape:'htmlall':'UTF-8'}</a></li>
+                                <li class="{$social_share_link.class|escape:'htmlall':'UTF-8'} icon-gray"><a href="{$social_share_link.url|escape:'htmlall':'UTF-8'}" class="visually-hidden" title="{$social_share_link.label|escape:'htmlall':'UTF-8'}" target="_blank">{$social_share_link.label|escape:'htmlall':'UTF-8'}</a></li>
                             {/foreach}
                             </ul>
                         </div>
@@ -187,7 +187,7 @@
             {if isset($show_post_tags) && $show_post_tags && isset($tags) && $tags}
             <div class="post-tags">
             {foreach from=$tags item=tag}
-                <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag->id, 'link_rewrite'=>$tag->link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge badge-info bg-info m-1" title="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">{$tag->title|escape:'htmlall':'UTF-8'}</a>
+                <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag->id, 'link_rewrite'=>$tag->link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge bg-info m-1" title="{$tag->title|escape:'htmlall':'UTF-8'} {$shop.name|escape:'htmlall':'UTF-8'}">{$tag->title|escape:'htmlall':'UTF-8'}</a>
             {/foreach}
             </div>
             {/if}

--- a/views/templates/hook/columns.tpl
+++ b/views/templates/hook/columns.tpl
@@ -46,11 +46,10 @@
 <div class="columns_everblog_wrapper tag_wrapper">
     <p class="text-uppercase h6 hidden-sm-down">{l s='Tags from the blog' mod='everpsblog'}</p>
 {foreach from=$tags item=tag}
-    <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag.id_ever_tag, 'link_rewrite' => $tag.link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge badge-info bg-info m-1 tag" title="{$tag.title|escape:'htmlall':'UTF-8'}">
+    <a href="{$link->getModuleLink('everpsblog', 'tag', ['id_ever_tag'=>$tag.id_ever_tag, 'link_rewrite' => $tag.link_rewrite])|escape:'htmlall':'UTF-8'}" class="badge bg-info m-1 tag" title="{$tag.title|escape:'htmlall':'UTF-8'}">
         {$tag.title|escape:'htmlall':'UTF-8'}
     </a>
 {/foreach}
 </div>
 {/if}
-
 

--- a/views/templates/hook/footer.tpl
+++ b/views/templates/hook/footer.tpl
@@ -21,9 +21,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">{l s='Image preview' mod='everpsblog'}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="{l s='Close' mod='everpsblog'}">
-                    <span aria-hidden="true">&times;</span>
-                </button>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' mod='everpsblog'}"></button>
             </div>
             <div class="modal-body text-center">
                 <img src="" alt="" class="img-fluid" />

--- a/views/templates/hook/home.tpl
+++ b/views/templates/hook/home.tpl
@@ -63,11 +63,11 @@
                 </div>
                 <a class="carousel-control-prev" role="button" data-bs-target="#{$carousel_id|escape:'htmlall':'UTF-8'}" data-bs-slide="prev">
                     <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                    <span class="sr-only visually-hidden">{l s='Previous' mod='everpsblog'}</span>
+                    <span class="visually-hidden">{l s='Previous' mod='everpsblog'}</span>
                 </a>
                 <a class="carousel-control-next" role="button" data-bs-target="#{$carousel_id|escape:'htmlall':'UTF-8'}" data-bs-slide="next">
                     <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                    <span class="sr-only visually-hidden">{l s='Next' mod='everpsblog'}</span>
+                    <span class="visually-hidden">{l s='Next' mod='everpsblog'}</span>
                 </a>
             </div>
         {else}


### PR DESCRIPTION
### Motivation
- Update front-facing templates to use Bootstrap 5 conventions by replacing deprecated Bootstrap 4 classes and data-attributes to avoid visual and accessibility regressions.
- Keep behavior unchanged while ensuring markup matches Bootstrap 5 expectations (modal close, badges, accessibility helpers, float utilities).

### Description
- Replaced `float-right` with `float-end` in the blog template by removing the old `float-right` usage and keeping `float-end` in `views/templates/front/blog.tpl`.
- Replaced accessibility and utility classes: `text-hide` → `visually-hidden` and removed `sr-only` usages in `views/templates/front/post.tpl` and `views/templates/hook/home.tpl`.
- Migrated badge classes from Bootstrap 4 (`badge badge-info`) to Bootstrap 5 style (`badge bg-info`) in `views/templates/front/post.tpl` and `views/templates/hook/columns.tpl`.
- Migrated modal close markup to Bootstrap 5 by replacing the old close button with `<button class="btn-close" data-bs-dismiss="modal">` in `views/templates/hook/footer.tpl`.

### Testing
- Ran targeted searches to validate removals with `rg -n "float-right|badge-info|text-hide|sr-only|data-dismiss=|class=\"close\"" views/templates/front views/templates/hook` and confirmed no remaining occurrences of the Bootstrap 4-only patterns in scanned templates (success).
- Verified modified files are present and the expected lines were updated by inspecting file snippets with `nl`/file listing (changes applied to `views/templates/front/blog.tpl`, `views/templates/front/post.tpl`, `views/templates/hook/columns.tpl`, `views/templates/hook/home.tpl`, and `views/templates/hook/footer.tpl`).
- Committed the changes after validation (local commit completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e25e81552c83228d2c183bcc624317)