### PR TITLE
Fix malformed Twitter image meta tag in post template

### DIFF
--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -25,7 +25,7 @@
     <meta name="twitter:title" content="{$page.meta.title|escape:'htmlall':'UTF-8'}">
     <meta name="twitter:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     {* <meta name="twitter:creator" content="@author_handle"> *}
-    <meta name="twitter:image" content="{$featured_image|escape:'htmlall':'UTF-8'}>
+    <meta name="twitter:image" content="{$featured_image|escape:'htmlall':'UTF-8'}">
     <!-- Open Graph Card data -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="{$urls.current_url|escape:'htmlall':'UTF-8'}">


### PR DESCRIPTION
### Motivation
- Fix a missing closing quote on the `twitter:image` meta tag that produced malformed HTML in the social metadata block and could break Twitter/Open Graph previews.

### Description
- Updated `views/templates/front/post.tpl` in the `{block name='head' append}` section to close the `twitter:image` content attribute by changing `<meta name="twitter:image" content="{$featured_image|escape:'htmlall':'UTF-8'}>` to `<meta name="twitter:image" content="{$featured_image|escape:'htmlall':'UTF-8'}">`.
- Quickly verified that adjacent Twitter/Open Graph meta tags in the same block remain correctly quoted.

### Testing
- Applied the patch with the automated patch tool (success) and validated the change by inspecting the template with `sed -n '1,220p' views/templates/front/post.tpl` and `nl -ba views/templates/front/post.tpl | sed -n '18,45p'`, which showed the corrected line and no other broken quotes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e26f700c708322ac20e478c2cd78cc)