### PR TITLE
Add multilingual hreflang alternates on front blog pages

### DIFF
--- a/controllers/front/author.php
+++ b/controllers/front/author.php
@@ -84,6 +84,11 @@ class EverPsBlogauthorModuleFrontController extends AuthorController
     {
         parent::initContent();
         if (Tools::getValue('id_ever_author')) {
+            $this->assignHreflangLinks('author', $this->getLocalizedParamsByLang(
+                'ever_blog_author_lang',
+                'id_ever_author',
+                (int) $this->author->id
+            ));
             $this->post_number = EverPsBlogPost::countPostsByAuthor(
                 (int) Tools::getValue('id_ever_author'),
                 (int) $this->context->language->id,

--- a/controllers/front/blog.php
+++ b/controllers/front/blog.php
@@ -136,6 +136,7 @@ class EverPsBlogblogModuleFrontController extends AbstractFrontController
     public function initContent()
     {
         parent::initContent();
+        $this->assignHreflangLinks('blog');
         $this->post_number = $this->getPostRowsCount(
             (int) $this->context->language->id,
             (int) $this->context->shop->id

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -90,6 +90,11 @@ class EverPsBlogcategoryModuleFrontController extends CategoryController
     {
         parent::initContent();
         if (Tools::getValue('id_ever_category')) {
+            $this->assignHreflangLinks('category', $this->getLocalizedParamsByLang(
+                'ever_blog_category_lang',
+                'id_ever_category',
+                (int) $this->category->id
+            ));
             $this->post_number = EverPsBlogPost::countPostsByCategory(
                 (int) Tools::getValue('id_ever_category'),
                 (int) $this->context->language->id,

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -192,6 +192,11 @@ class EverPsBlogpostModuleFrontController extends PostController
     {
         parent::initContent();
         if (Tools::getValue('id_ever_post')) {
+            $this->assignHreflangLinks('post', $this->getLocalizedParamsByLang(
+                'ever_blog_post_lang',
+                'id_ever_post',
+                (int) $this->post->id
+            ));
             $errors = [];
             $success = [];
             $animate = Configuration::get(

--- a/controllers/front/tag.php
+++ b/controllers/front/tag.php
@@ -81,6 +81,11 @@ class EverPsBlogtagModuleFrontController extends TagController
     {
         parent::initContent();
         if (Tools::getValue('id_ever_tag')) {
+            $this->assignHreflangLinks('tag', $this->getLocalizedParamsByLang(
+                'ever_blog_tag_lang',
+                'id_ever_tag',
+                (int) $this->tag->id
+            ));
             $this->post_number = EverPsBlogPost::countPostsByTag(
                 (int) Tools::getValue('id_ever_tag'),
                 (int) $this->context->language->id,

--- a/src/Controller/Front/AbstractFrontController.php
+++ b/src/Controller/Front/AbstractFrontController.php
@@ -241,4 +241,121 @@ abstract class AbstractFrontController extends \ModuleFrontController
         header('Cache-Control: no-cache');
         \Tools::redirectLink($finalUrl);
     }
+
+    /**
+     * @param array<int, array<string, int|string>> $localizedParamsByLang
+     */
+    protected function assignHreflangLinks(string $controllerName, array $localizedParamsByLang = []): void
+    {
+        $idShop = (int) $this->context->shop->id;
+        $defaultLangId = (int) \Configuration::get('PS_LANG_DEFAULT');
+        $currentPage = (int) \Tools::getValue('page');
+        $hreflangLinks = [];
+        $xDefaultHref = '';
+
+        foreach (\Language::getLanguages(true, $idShop) as $language) {
+            $idLang = (int) ($language['id_lang'] ?? 0);
+            if ($idLang <= 0) {
+                continue;
+            }
+
+            $params = $localizedParamsByLang[$idLang] ?? [];
+            if ($currentPage > 1) {
+                $params['page'] = $currentPage;
+            }
+
+            $href = $this->context->link->getModuleLink(
+                $this->module->name,
+                $controllerName,
+                $params,
+                true,
+                $idLang,
+                $idShop
+            );
+
+            if (!$href) {
+                continue;
+            }
+
+            $hreflangLinks[] = [
+                'hreflang' => $this->formatHreflangCode((array) $language),
+                'href' => $href,
+            ];
+
+            if ($idLang === $defaultLangId) {
+                $xDefaultHref = $href;
+            }
+        }
+
+        if (!$xDefaultHref && !empty($hreflangLinks[0]['href'])) {
+            $xDefaultHref = (string) $hreflangLinks[0]['href'];
+        }
+
+        $this->context->smarty->assign([
+            'hreflang_links' => $hreflangLinks,
+            'hreflang_x_default' => $xDefaultHref,
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, int|string>>
+     */
+    protected function getLocalizedParamsByLang(string $langTable, string $idColumn, int $resourceId): array
+    {
+        if ($resourceId <= 0) {
+            return [];
+        }
+
+        $sql = sprintf(
+            'SELECT `id_lang`, `%s`, `link_rewrite`
+            FROM `%s%s`
+            WHERE `%s` = %d',
+            \pSQL($idColumn),
+            _DB_PREFIX_,
+            \pSQL($langTable),
+            \pSQL($idColumn),
+            $resourceId
+        );
+
+        $rows = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
+        if (!$rows) {
+            return [];
+        }
+
+        $paramsByLang = [];
+        foreach ($rows as $row) {
+            $idLang = (int) ($row['id_lang'] ?? 0);
+            $idValue = (int) ($row[$idColumn] ?? 0);
+            $linkRewrite = (string) ($row['link_rewrite'] ?? '');
+
+            if ($idLang <= 0 || $idValue <= 0 || $linkRewrite === '') {
+                continue;
+            }
+
+            $paramsByLang[$idLang] = [
+                $idColumn => $idValue,
+                'link_rewrite' => $linkRewrite,
+            ];
+        }
+
+        return $paramsByLang;
+    }
+
+    private function formatHreflangCode(array $language): string
+    {
+        $locale = (string) ($language['locale'] ?? $language['language_code'] ?? $language['iso_code'] ?? '');
+        $locale = str_replace('_', '-', $locale);
+        $parts = array_values(array_filter(explode('-', $locale)));
+
+        if (empty($parts)) {
+            return 'x-default';
+        }
+
+        $code = strtolower((string) $parts[0]);
+        if (!empty($parts[1])) {
+            $code .= '-' . strtoupper((string) $parts[1]);
+        }
+
+        return $code;
+    }
 }

--- a/views/templates/front/author.tpl
+++ b/views/templates/front/author.tpl
@@ -33,6 +33,14 @@
     <meta property="og:site_name" content="{$shop.name|escape:'htmlall':'UTF-8'}">
     <meta property="og:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     <meta property="og:image" content="{$blogImg_dir|escape:'htmlall':'UTF-8'}authors/author_image_{$author->id|escape:'htmlall':'UTF-8'}.jpg">
+    {if isset($hreflang_links) && $hreflang_links}
+        {foreach from=$hreflang_links item=hreflang_link}
+            <link rel="alternate" hreflang="{$hreflang_link.hreflang|escape:'htmlall':'UTF-8'}" href="{$hreflang_link.href|escape:'htmlall':'UTF-8'}">
+        {/foreach}
+        {if isset($hreflang_x_default) && $hreflang_x_default}
+            <link rel="alternate" hreflang="x-default" href="{$hreflang_x_default|escape:'htmlall':'UTF-8'}">
+        {/if}
+    {/if}
     {if isset($allow_feed) && $allow_feed}
     <link rel="alternate" type="application/rss+xml" title="{$page.meta.title|escape:'htmlall':'UTF-8'} {if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}" href="{$feed_url|escape:'htmlall':'UTF-8'}" />
     {/if}

--- a/views/templates/front/blog.tpl
+++ b/views/templates/front/blog.tpl
@@ -33,6 +33,14 @@
     <meta property="og:site_name" content="{$shop.name|escape:'htmlall':'UTF-8'}">
     <meta property="og:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     <meta property="og:image" content="{$shop.logo|escape:'htmlall':'UTF-8'}">
+    {if isset($hreflang_links) && $hreflang_links}
+        {foreach from=$hreflang_links item=hreflang_link}
+            <link rel="alternate" hreflang="{$hreflang_link.hreflang|escape:'htmlall':'UTF-8'}" href="{$hreflang_link.href|escape:'htmlall':'UTF-8'}">
+        {/foreach}
+        {if isset($hreflang_x_default) && $hreflang_x_default}
+            <link rel="alternate" hreflang="x-default" href="{$hreflang_x_default|escape:'htmlall':'UTF-8'}">
+        {/if}
+    {/if}
     {if isset($allow_feed) && $allow_feed}
     <link rel="alternate" type="application/rss+xml" title="{$page.meta.title|escape:'htmlall':'UTF-8'} {if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}" href="{$feed_url|escape:'htmlall':'UTF-8'}" />
     {/if}

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -33,6 +33,14 @@
     <meta property="og:site_name" content="{$shop.name|escape:'htmlall':'UTF-8'}">
     <meta property="og:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     <meta property="og:image" content="{$blogImg_dir|escape:'htmlall':'UTF-8'}categories/category_image_{$category->id|escape:'htmlall':'UTF-8'}.jpg">
+    {if isset($hreflang_links) && $hreflang_links}
+        {foreach from=$hreflang_links item=hreflang_link}
+            <link rel="alternate" hreflang="{$hreflang_link.hreflang|escape:'htmlall':'UTF-8'}" href="{$hreflang_link.href|escape:'htmlall':'UTF-8'}">
+        {/foreach}
+        {if isset($hreflang_x_default) && $hreflang_x_default}
+            <link rel="alternate" hreflang="x-default" href="{$hreflang_x_default|escape:'htmlall':'UTF-8'}">
+        {/if}
+    {/if}
     {if isset($allow_feed) && $allow_feed}
     <link rel="alternate" type="application/rss+xml" title="{$page.meta.title|escape:'htmlall':'UTF-8'} {if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}" href="{$feed_url|escape:'htmlall':'UTF-8'}" />
     {/if}

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -33,6 +33,14 @@
     <meta property="og:site_name" content="{$shop.name|escape:'htmlall':'UTF-8'}">
     <meta property="og:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     <meta property="og:image" content="{$featured_image|escape:'htmlall':'UTF-8'}">
+    {if isset($hreflang_links) && $hreflang_links}
+        {foreach from=$hreflang_links item=hreflang_link}
+            <link rel="alternate" hreflang="{$hreflang_link.hreflang|escape:'htmlall':'UTF-8'}" href="{$hreflang_link.href|escape:'htmlall':'UTF-8'}">
+        {/foreach}
+        {if isset($hreflang_x_default) && $hreflang_x_default}
+            <link rel="alternate" hreflang="x-default" href="{$hreflang_x_default|escape:'htmlall':'UTF-8'}">
+        {/if}
+    {/if}
     <script type="application/ld+json">
     {
     "@context": "https://schema.org",

--- a/views/templates/front/tag.tpl
+++ b/views/templates/front/tag.tpl
@@ -33,6 +33,14 @@
     <meta property="og:site_name" content="{$shop.name|escape:'htmlall':'UTF-8'}">
     <meta property="og:description" content="{$page.meta.description|escape:'htmlall':'UTF-8'}">
     <meta property="og:image" content="{$blogImg_dir|escape:'htmlall':'UTF-8'}tags/tag_image_{$tag->id|escape:'htmlall':'UTF-8'}.jpg">
+    {if isset($hreflang_links) && $hreflang_links}
+        {foreach from=$hreflang_links item=hreflang_link}
+            <link rel="alternate" hreflang="{$hreflang_link.hreflang|escape:'htmlall':'UTF-8'}" href="{$hreflang_link.href|escape:'htmlall':'UTF-8'}">
+        {/foreach}
+        {if isset($hreflang_x_default) && $hreflang_x_default}
+            <link rel="alternate" hreflang="x-default" href="{$hreflang_x_default|escape:'htmlall':'UTF-8'}">
+        {/if}
+    {/if}
     {if isset($allow_feed) && $allow_feed}
     <link rel="alternate" type="application/rss+xml" title="{$page.meta.title|escape:'htmlall':'UTF-8'} {if isset($pagination) && $pagination.current_page > 0}{l s='(page' mod='everpsblog'} {$pagination.current_page|escape:'htmlall':'UTF-8'}/{$pagination.pages_count|escape:'htmlall':'UTF-8'}{l s=')' mod='everpsblog'}{/if}" href="{$feed_url|escape:'htmlall':'UTF-8'}" />
     {/if}


### PR DESCRIPTION
### Motivation
- Permettre la génération d'en-têtes `rel="alternate" hreflang="xx-YY"` pour les pages front du blog afin d'exposer des URLs localisées par langue (posts, catégories, tags, auteurs et page blog). 

### Description
- Ajout de fonctions réutilisables dans `AbstractFrontController` : `assignHreflangLinks()`, `getLocalizedParamsByLang()` et `formatHreflangCode()` qui construisent des URLs par langue via `Link::getModuleLink(..., id_lang)` et normalisent les codes hreflang. 
- Injection Smarty des variables `hreflang_links` et `hreflang_x_default` depuis le contrôleur pour être consommées en template. 
- Appel de `assignHreflangLinks()` intégré aux contrôleurs front concernés : `controllers/front/blog.php`, `post.php`, `category.php`, `tag.php` et `author.php`. 
- Mise à jour des templates front `views/templates/front/{blog,post,category,tag,author}.tpl` pour boucler sur `hreflang_links` et ajouter le fallback `x-default` en head.

### Testing
- Exécution de la vérification syntaxique PHP (`php -l`) sur les fichiers modifiés ciblés et sur l'abstract controller, tous les contrôles sont passés avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2708394a48322aacf77a72eb43f92)