### PR TITLE
chore: update license copyright year to 2026

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2019-2025 Team Ever.
+Copyright (c) 2019-2026 Team Ever.
 
 Academic Free License ("AFL") v. 3.0
 


### PR DESCRIPTION
### Motivation
- Bump the copyright range in `LICENSE.md` from `2019-2025` to `2019-2026` to reflect the new year.

### Description
- Update the single copyright line in `LICENSE.md` from `Copyright (c) 2019-2025 Team Ever.` to `Copyright (c) 2019-2026 Team Ever.`.

### Testing
- Verified the change with `rg -n "2025" LICENSE.md`, reviewed the patch with `git diff -- LICENSE.md`, and committed the update with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ca9cb5948322b0c734eb214bb0e8)