### PR TITLE
Avoid Symfony container in front controllers by manual service instantiation

### DIFF
--- a/controllers/front/author.php
+++ b/controllers/front/author.php
@@ -259,17 +259,17 @@ class EverPsBlogauthorModuleFrontController extends AuthorController
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/controllers/front/blog.php
+++ b/controllers/front/blog.php
@@ -337,17 +337,17 @@ class EverPsBlogblogModuleFrontController extends AbstractFrontController
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -289,17 +289,17 @@ class EverPsBlogcategoryModuleFrontController extends CategoryController
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/controllers/front/customercomments.php
+++ b/controllers/front/customercomments.php
@@ -131,17 +131,17 @@ class EverPsBlogcustomercommentsModuleFrontController extends CustomerCommentsCo
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -630,17 +630,17 @@ class EverPsBlogpostModuleFrontController extends PostController
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/controllers/front/tag.php
+++ b/controllers/front/tag.php
@@ -236,17 +236,17 @@ class EverPsBlogtagModuleFrontController extends TagController
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        return parent::getBlogImageService();
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        return parent::getBlogTaxonomyService();
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        return parent::getBlogSortOrderService();
     }
 
 }

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -30,6 +30,14 @@ class EverPsBlog extends Module
     private $html;
     private $postErrors = [];
     private $postSuccess = [];
+    private $blogInstallService;
+    private $blogTaxonomyService;
+    private $blogImageService;
+    private $blogCleanerService;
+    private $blogSortOrderService;
+    private $blogSitemapService;
+    private $legacyImportAdapter;
+    private $serviceCachePool;
     public static $route = [];
 
     public function __construct()
@@ -188,33 +196,35 @@ class EverPsBlog extends Module
         return $tab->delete();
     }
 
-    private function getModuleService($serviceId)
-    {
-        if (method_exists($this, 'get')) {
-            return $this->get($serviceId);
-        }
-
-        return \PrestaShop\PrestaShop\Adapter\SymfonyContainer::getInstance()->get($serviceId);
-    }
-
     private function getBlogInstallService()
     {
-        try {
-            return $this->getModuleService('prestashop.module.everpsblog.service.blog_install');
-        } catch (\Throwable $exception) {
-            // During module install, module Symfony services can be unavailable.
-            return new \PrestaShop\Module\Everpsblog\Service\BlogInstallService();
+        if (!$this->blogInstallService) {
+            $this->blogInstallService = new \PrestaShop\Module\Everpsblog\Service\BlogInstallService();
         }
+
+        return $this->blogInstallService;
     }
 
     private function getBlogTaxonomyService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_taxonomy');
+        if (!$this->blogTaxonomyService) {
+            $this->blogTaxonomyService = new \PrestaShop\Module\Everpsblog\Service\BlogTaxonomyService(
+                $this->getServiceCachePool()
+            );
+        }
+
+        return $this->blogTaxonomyService;
     }
 
     private function getBlogImageService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_image');
+        if (!$this->blogImageService) {
+            $this->blogImageService = new \PrestaShop\Module\Everpsblog\Service\BlogImageService(
+                $this->getServiceCachePool()
+            );
+        }
+
+        return $this->blogImageService;
     }
 
 
@@ -278,22 +288,49 @@ class EverPsBlog extends Module
 
     private function getBlogCleanerService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_cleaner');
+        if (!$this->blogCleanerService) {
+            $this->blogCleanerService = new \PrestaShop\Module\Everpsblog\Service\BlogCleanerService();
+        }
+
+        return $this->blogCleanerService;
     }
 
     private function getBlogSortOrderService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sort_order');
+        if (!$this->blogSortOrderService) {
+            $this->blogSortOrderService = new \PrestaShop\Module\Everpsblog\Service\BlogSortOrderService();
+        }
+
+        return $this->blogSortOrderService;
     }
 
     private function getBlogSitemapService()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.blog_sitemap');
+        if (!$this->blogSitemapService) {
+            $this->blogSitemapService = new \PrestaShop\Module\Everpsblog\Service\BlogSitemapService();
+        }
+
+        return $this->blogSitemapService;
     }
 
     private function getLegacyImportAdapter()
     {
-        return $this->getModuleService('prestashop.module.everpsblog.service.legacy_import_adapter');
+        if (!$this->legacyImportAdapter) {
+            $this->legacyImportAdapter = new \PrestaShop\Module\Everpsblog\Service\LegacyImportAdapter(
+                $this->getBlogImageService()
+            );
+        }
+
+        return $this->legacyImportAdapter;
+    }
+
+    private function getServiceCachePool()
+    {
+        if (!$this->serviceCachePool) {
+            $this->serviceCachePool = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+        }
+
+        return $this->serviceCachePool;
     }
 
     /**

--- a/src/Controller/Front/AbstractFrontController.php
+++ b/src/Controller/Front/AbstractFrontController.php
@@ -5,13 +5,16 @@ declare(strict_types=1);
 namespace PrestaShop\Module\Everpsblog\Controller\Front;
 
 use PrestaShop\PrestaShop\Core\Product\Search\Pagination;
-use PrestaShop\PrestaShop\Adapter\SymfonyContainer;
 
 require_once dirname(__DIR__, 3) . '/everpsblog.php';
 
 abstract class AbstractFrontController extends \ModuleFrontController
 {
     protected $page = 1;
+    private $blogImageService;
+    private $blogTaxonomyService;
+    private $blogSortOrderService;
+    private $serviceCachePool;
 
     public function getTemplateVarPage()
     {
@@ -139,24 +142,6 @@ abstract class AbstractFrontController extends \ModuleFrontController
         ];
     }
 
-
-    protected function getModuleService(string $serviceId)
-    {
-        if (isset($this->module) && method_exists($this->module, 'get')) {
-            try {
-                return $this->module->get($serviceId);
-            } catch (\Throwable $exception) {
-                // Fallback to legacy Symfony container access below.
-            }
-        }
-
-        $container = SymfonyContainer::getInstance();
-        if (null === $container) {
-            throw new \RuntimeException(sprintf('Symfony container is unavailable for service "%s".', $serviceId));
-        }
-
-        return $container->get($serviceId);
-    }
 
     protected function getTemplateVarPagination($total = 0)
     {
@@ -357,5 +342,45 @@ abstract class AbstractFrontController extends \ModuleFrontController
         }
 
         return $code;
+    }
+
+    protected function getBlogImageService()
+    {
+        if (!$this->blogImageService) {
+            $this->blogImageService = new \PrestaShop\Module\Everpsblog\Service\BlogImageService(
+                $this->getServiceCachePool()
+            );
+        }
+
+        return $this->blogImageService;
+    }
+
+    protected function getBlogTaxonomyService()
+    {
+        if (!$this->blogTaxonomyService) {
+            $this->blogTaxonomyService = new \PrestaShop\Module\Everpsblog\Service\BlogTaxonomyService(
+                $this->getServiceCachePool()
+            );
+        }
+
+        return $this->blogTaxonomyService;
+    }
+
+    protected function getBlogSortOrderService()
+    {
+        if (!$this->blogSortOrderService) {
+            $this->blogSortOrderService = new \PrestaShop\Module\Everpsblog\Service\BlogSortOrderService();
+        }
+
+        return $this->blogSortOrderService;
+    }
+
+    private function getServiceCachePool()
+    {
+        if (!$this->serviceCachePool) {
+            $this->serviceCachePool = new \Symfony\Component\Cache\Adapter\ArrayAdapter();
+        }
+
+        return $this->serviceCachePool;
     }
 }


### PR DESCRIPTION
### Motivation
- Front-office legacy controllers were calling the Symfony container (e.g. `SymfonyContainer::getInstance()->get(...)` / module `get()`), which is often null or unavailable in `ModuleFrontController` flows and causes runtime failures.
- Ensure front-office execution does not depend on the Symfony DI container while keeping business logic and method signatures unchanged.

### Description
- Removed direct container lookups for legacy/front flows and replaced them with dedicated, cached manual-instantiation getters in the module (`everpsblog.php`) for services: `BlogInstallService`, `BlogTaxonomyService`, `BlogImageService`, `BlogCleanerService`, `BlogSortOrderService`, `BlogSitemapService`, `LegacyImportAdapter`, and a shared cache pool (`ArrayAdapter`).
- Removed container fallback from `AbstractFrontController` and implemented safe front-compatible getters (`getBlogImageService`, `getBlogTaxonomyService`, `getBlogSortOrderService`) plus a local `getServiceCachePool` to provide required cache dependencies without the container.
- Updated front controllers (`controllers/front/blog.php`, `post.php`, `author.php`, `category.php`, `customercomments.php`, `tag.php`) to call the new parent getters (e.g. `parent::getBlogImageService()`) instead of resolving services by id.
- Added simple instance caching to avoid repeated instantiation of services when used multiple times.

### Testing
- Ran syntax checks with `php -l` on `everpsblog.php`, `src/Controller/Front/AbstractFrontController.php` and updated front controllers, and all reported `No syntax errors detected`.
- Searched for remaining container-dependent patterns with ripgrep and verified there are no remaining matches for `SymfonyContainer::getInstance()`, `getModuleService(` or `getContainer(` in legacy/front code paths.
- All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cb7360248322a78409a37fe3bfe0)