### PR TITLE
Fix fatal visibility error in blog front controller

### DIFF
--- a/controllers/front/blog.php
+++ b/controllers/front/blog.php
@@ -335,17 +335,17 @@ class EverPsBlogblogModuleFrontController extends AbstractFrontController
         return $page;
     }
 
-    private function getBlogImageService()
+    protected function getBlogImageService()
     {
         return parent::getBlogImageService();
     }
 
-    private function getBlogTaxonomyService()
+    protected function getBlogTaxonomyService()
     {
         return parent::getBlogTaxonomyService();
     }
 
-    private function getBlogSortOrderService()
+    protected function getBlogSortOrderService()
     {
         return parent::getBlogSortOrderService();
     }


### PR DESCRIPTION
### Motivation
- Prevent a runtime fatal error caused by the child controller narrowing the visibility of inherited service accessor methods compared to `AbstractFrontController`.

### Description
- Changed the visibility of `getBlogImageService()`, `getBlogTaxonomyService()`, and `getBlogSortOrderService()` from `private` to `protected` in `controllers/front/blog.php` so they are not stricter than the parent class.

### Testing
- Ran `php -l controllers/front/blog.php` and it returned "No syntax errors detected."

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cdd1e62c8322bfc39d10bf216722)