### PR TITLE
Fix category list visibility after BO save

### DIFF
--- a/src/Grid/Data/CategoryGridDataFactory.php
+++ b/src/Grid/Data/CategoryGridDataFactory.php
@@ -44,9 +44,11 @@ final class CategoryGridDataFactory
         $records = [];
 
         foreach ($rows as $row) {
+            $translation = $row['cl'] ?? [];
+            $title = is_array($translation) ? (string) ($translation['title'] ?? '') : '';
             $records[] = [
                 'id_ever_category' => $row['id'] ?? $row['id'.substr('id_ever_category',3)] ?? 0,
-                'title' => $row['cl']['title'] ?? '',
+                'title' => $title,
                 'active' => (string) ($row['active'] ?? 0)
             ];
         }

--- a/src/Repository/CategoryRepository.php
+++ b/src/Repository/CategoryRepository.php
@@ -66,6 +66,7 @@ class CategoryRepository extends EntityRepository
     private function createLocalizedQb($shopId, $langId)
     {
         return $this->createQueryBuilder('c')
+            ->addSelect('cl')
             ->innerJoin('c.translations', 'cl')
             ->innerJoin('c.shops', 'cs')
             ->andWhere('cl.langId = :langId')


### PR DESCRIPTION
### Motivation
- Newly saved categories could appear without a usable title in the Back Office list because Doctrine array hydration did not include the joined translation alias, making them effectively invisible.
- The grid data factory assumed translation data was always present which could lead to empty `title` values when the joined translation row was not part of the result.

### Description
- Add `->addSelect('cl')` to `createLocalizedQb` in `src/Repository/CategoryRepository.php` so the translation alias is included in the Doctrine query result.
- Harden the mapping in `src/Grid/Data/CategoryGridDataFactory.php` to safely read the translated title from `$row['cl']` with a fallback when the structure differs.
- Changed files: `src/Repository/CategoryRepository.php`, `src/Grid/Data/CategoryGridDataFactory.php`.

### Testing
- Ran `php -l src/Repository/CategoryRepository.php` which returned no syntax errors.
- Ran `php -l src/Grid/Data/CategoryGridDataFactory.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5da9162308322a3e16dd65c2f276f)