### PR TITLE
Fix back-office category save payload normalization

### DIFF
--- a/src/Application/Blog/CategoryCommandAssembler.php
+++ b/src/Application/Blog/CategoryCommandAssembler.php
@@ -21,6 +21,7 @@ class CategoryCommandAssembler
 
     public function assembleCreate(array $requestData): CreateCategoryCommand
     {
+        $requestData = $this->extractPayload($requestData);
         $validatedData = $this->validator->validate($requestData);
 
         return new CreateCategoryCommand($this->mergeDefaults($validatedData));
@@ -28,6 +29,7 @@ class CategoryCommandAssembler
 
     public function assembleUpdate(int $categoryId, array $requestData): UpdateCategoryCommand
     {
+        $requestData = $this->extractPayload($requestData);
         $validatedData = $this->validator->validate($requestData);
 
         return new UpdateCategoryCommand($categoryId, $this->mergeDefaults($validatedData));
@@ -35,7 +37,7 @@ class CategoryCommandAssembler
 
     private function mergeDefaults(array $data): array
     {
-        return array_merge([
+        $normalizedData = array_merge([
             'id_shop' => $this->shopId,
             'title' => '',
             'meta_title' => '',
@@ -51,5 +53,23 @@ class CategoryCommandAssembler
             'allowed_groups' => [],
             'category_products' => [],
         ], $data);
+
+        if ('' === ($normalizedData['id_parent_category'] ?? null)) {
+            $normalizedData['id_parent_category'] = null;
+        }
+
+        return $normalizedData;
+    }
+
+    private function extractPayload(array $requestData): array
+    {
+        if (isset($requestData['category']) && is_array($requestData['category'])) {
+            /** @var array<string, mixed> $categoryPayload */
+            $categoryPayload = $requestData['category'];
+
+            return $categoryPayload;
+        }
+
+        return $requestData;
     }
 }


### PR DESCRIPTION
### Motivation
- Categories could fail to save from the back office because the controller form sometimes posts a nested `category[...]` payload while the assembler expected a flat array. 
- An empty string for `id_parent_category` could be persisted as `''` which may cause issues with DB constraints or relation checks.

### Description
- Added an `extractPayload` helper to `CategoryCommandAssembler` and call it from `assembleCreate` and `assembleUpdate` to accept both nested `category[...]` payloads and flat arrays. 
- Coerce an empty `id_parent_category` string to `null` in `mergeDefaults` so parent IDs are either integers or `null`. 
- Keep existing default merging behavior and apply the normalization for both create and update command assembly.

### Testing
- Ran `php -l src/Application/Blog/CategoryCommandAssembler.php` which reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e1d751188322a362f53c46508a82)