### PR TITLE
feat(front): enable QCD Page Builder rendering on EverPSBlog front pages

### DIFF
--- a/controllers/front/author.php
+++ b/controllers/front/author.php
@@ -128,10 +128,18 @@ class EverPsBlogauthorModuleFrontController extends AbstractFrontController
             $this->context->smarty->assign('page', $page);
             // Now prepare template and show it
             // Prepare shortcodes
-            $this->author->content = 
-                $this->author->content;
-            $this->author->bottom_content = 
-                $this->author->bottom_content;
+            $this->author->content = $this->renderQcdBuilderField(
+                'everpsblog_author',
+                (int) $this->author->id,
+                'content',
+                (string) $this->author->content
+            );
+            $this->author->bottom_content = $this->renderQcdBuilderField(
+                'everpsblog_author',
+                (int) $this->author->id,
+                'bottom_content',
+                (string) $this->author->bottom_content
+            );
             $this->author->nickhandle = 
                 $this->author->nickhandle;
             $posts = $this->getFrontPostsByAuthor(

--- a/controllers/front/category.php
+++ b/controllers/front/category.php
@@ -154,10 +154,18 @@ class EverPsBlogcategoryModuleFrontController extends AbstractFrontController
             } else {
                 $children_categories = false;
             }
-            $this->category->content = 
-                $this->category->content;
-            $this->category->bottom_content = 
-                $this->category->bottom_content;
+            $this->category->content = $this->renderQcdBuilderField(
+                'everpsblog_category',
+                (int) $this->category->id,
+                'content',
+                (string) $this->category->content
+            );
+            $this->category->bottom_content = $this->renderQcdBuilderField(
+                'everpsblog_category',
+                (int) $this->category->id,
+                'bottom_content',
+                (string) $this->category->bottom_content
+            );
             $postsViewModel = PostViewModel::listFromLegacy($posts);
             $categoryViewModel = TaxonomyViewModel::fromLegacy($this->category, 'category');
             Hook::exec('actionBeforeEverCategoryInitContent', [

--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -419,8 +419,12 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
                             $cookieName,
                             true
                         );
-                        $this->post->content = 
-                            $this->post->content;
+                        $this->post->content = $this->renderQcdBuilderField(
+                            'everpsblog_post',
+                            (int) $this->post->id,
+                            'content',
+                            (string) $this->post->content
+                        );
                     }
                 } else {
                     $this->post->password_protected = true;
@@ -428,8 +432,12 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
                 }
             } else {
                 // Prepare shortcodes
-                $this->post->content = 
-                    $this->post->content;
+                $this->post->content = $this->renderQcdBuilderField(
+                    'everpsblog_post',
+                    (int) $this->post->id,
+                    'content',
+                    (string) $this->post->content
+                );
             }
             $this->post->title = 
                 $this->post->title;

--- a/src/Controller/Front/AbstractFrontController.php
+++ b/src/Controller/Front/AbstractFrontController.php
@@ -15,6 +15,8 @@ abstract class AbstractFrontController extends \ModuleFrontController
     private $blogTaxonomyService;
     private $blogSortOrderService;
     private $serviceCachePool;
+    private $qcdBuilderModule;
+    private $qcdBuilderModuleResolved = false;
 
     public function getTemplateVarPage()
     {
@@ -155,6 +157,44 @@ abstract class AbstractFrontController extends \ModuleFrontController
         ];
     }
 
+
+    protected function renderQcdBuilderField(string $targetType, int $targetId, string $targetField, string $fallbackContent): string
+    {
+        $builder = $this->getQcdBuilderModule();
+        if (!$builder || !method_exists($builder, 'renderTargetField')) {
+            return $fallbackContent;
+        }
+
+        return (string) $builder->renderTargetField(
+            $targetType,
+            $targetId,
+            $targetField,
+            $fallbackContent,
+            (int) $this->context->shop->id,
+            (int) $this->context->language->id
+        );
+    }
+
+    protected function getQcdBuilderModule(): ?\Module
+    {
+        if ($this->qcdBuilderModuleResolved) {
+            return $this->qcdBuilderModule;
+        }
+
+        static $cachedQcdBuilderModule;
+        static $cachedQcdBuilderModuleResolved = false;
+
+        if (!$cachedQcdBuilderModuleResolved) {
+            $module = \Module::getInstanceByName('qcdpagebuilder');
+            $cachedQcdBuilderModule = ($module instanceof \Module) ? $module : null;
+            $cachedQcdBuilderModuleResolved = true;
+        }
+
+        $this->qcdBuilderModule = $cachedQcdBuilderModule;
+        $this->qcdBuilderModuleResolved = true;
+
+        return $this->qcdBuilderModule;
+    }
 
     protected function getTemplateVarPagination($total = 0)
     {


### PR DESCRIPTION
### Motivation
- Allow content edited with QCD Page Builder to be rendered on public blog pages (posts, categories, authors) so front displays reflect builder changes.

### Description
- Add cached module resolution (`$qcdBuilderModule`, `$qcdBuilderModuleResolved`) and helpers `renderQcdBuilderField()` and `getQcdBuilderModule()` to `AbstractFrontController` to safely resolve `qcdpagebuilder` and call `renderTargetField()` with shop and language context, falling back to native content when unavailable.
- Use `renderQcdBuilderField()` for post rendering (target `everpsblog_post` / field `content`), including the password-protected branch so rendered content is used after successful validation.
- Use `renderQcdBuilderField()` for category pages (target `everpsblog_category` / fields `content` and `bottom_content`).
- Use `renderQcdBuilderField()` for author pages (target `everpsblog_author` / fields `content` and `bottom_content`).

### Testing
- Ran `php -l src/Controller/Front/AbstractFrontController.php` with no syntax errors.
- Ran `php -l controllers/front/post.php` with no syntax errors.
- Ran `php -l controllers/front/category.php` with no syntax errors.
- Ran `php -l controllers/front/author.php` with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e794f8ad28832587b3752e2e474a61)