### PR TITLE
Improve BO image previews with cache busting and modal

### DIFF
--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -351,10 +351,11 @@ class AuthorController extends AbstractDomainController
         }
 
         $url = (string) $this->blogImageService->getBlogImageUrl($authorId, $shopId, 'author');
-        $escapedUrl = htmlspecialchars($url, ENT_QUOTES, 'UTF-8');
+        $previewUrl = $this->appendTimestampToUrl($url);
+        $escapedUrl = htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8');
 
         return sprintf(
-            '<span class="ever-featured-image-preview"><img src="%1$s" alt="%2$s" loading="lazy"><span>%3$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%4$s</a></span></span>',
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%3$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%4$s</a></span></span>',
             $escapedUrl,
             htmlspecialchars($this->transAdmin('Current author image'), ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($this->transAdmin('Current image'), ENT_QUOTES, 'UTF-8'),
@@ -407,5 +408,12 @@ class AuthorController extends AbstractDomainController
         if (!$this->isCsrfTokenValid($tokenId, $token)) {
             throw $this->createAccessDeniedException('Invalid CSRF token.');
         }
+    }
+
+    private function appendTimestampToUrl(string $url): string
+    {
+        $separator = false === strpos($url, '?') ? '?' : '&';
+
+        return $url . $separator . 't=' . time();
     }
 }

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -557,13 +557,21 @@ class PostController extends AbstractDomainController
         if ('' === $url) {
             return '';
         }
+        $previewUrl = $this->appendTimestampToUrl($url);
 
         return sprintf(
-            '%s: <a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
-            $label,
-            htmlspecialchars($url, ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars($url, ENT_QUOTES, 'UTF-8')
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%3$s</a></span></span>',
+            htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($this->transAdmin('open in a new tab'), ENT_QUOTES, 'UTF-8')
         );
+    }
+
+    private function appendTimestampToUrl(string $url): string
+    {
+        $separator = false === strpos($url, '?') ? '?' : '&';
+
+        return $url . $separator . 't=' . time();
     }
 
 }

--- a/src/Service/AdminBlogImageManager.php
+++ b/src/Service/AdminBlogImageManager.php
@@ -100,12 +100,21 @@ class AdminBlogImageManager
             return '';
         }
 
+        $previewUrl = $this->appendTimestampToUrl($url);
+
         return sprintf(
-            '<span class="ever-featured-image-preview"><img src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%3$s</a></span></span>',
-            htmlspecialchars($url, ENT_QUOTES, 'UTF-8'),
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%3$s</a></span></span>',
+            htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($openLabel, ENT_QUOTES, 'UTF-8')
         );
+    }
+
+    private function appendTimestampToUrl(string $url): string
+    {
+        $separator = false === strpos($url, '?') ? '?' : '&';
+
+        return $url . $separator . 't=' . time();
     }
 
     private function deleteFiles(int $elementId, string $imageType): void

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -174,12 +174,54 @@
     }
     .ever-featured-image-preview img {
       display: block;
-      max-width: 220px;
+      max-width: 320px;
+      max-height: 180px;
       height: auto;
       border: 1px solid var(--ever-border);
       border-radius: 10px;
       margin-bottom: .45rem;
       background: #fff;
+      cursor: zoom-in;
+    }
+
+    .ever-image-preview-modal {
+      position: fixed;
+      inset: 0;
+      background: rgba(17, 24, 39, .75);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 1060;
+      padding: 1.5rem;
+    }
+
+    .ever-image-preview-modal.is-open {
+      display: flex;
+    }
+
+    .ever-image-preview-modal img {
+      display: block;
+      max-width: min(1100px, 92vw);
+      max-height: 88vh;
+      border-radius: 10px;
+      box-shadow: 0 35px 80px -40px rgba(0, 0, 0, .9);
+      background: #fff;
+    }
+
+    .ever-image-preview-modal-close {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
+      border: 0;
+      width: 2rem;
+      height: 2rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, .95);
+      color: #111827;
+      font-size: 1.2rem;
+      line-height: 1;
+      font-weight: 700;
+      cursor: pointer;
     }
 
     .ever-admin-form .form-control-label,
@@ -708,6 +750,49 @@
 
       root.addEventListener('input', function () {
         refreshLangValidation();
+      });
+
+      var previewModal = document.createElement('div');
+      previewModal.className = 'ever-image-preview-modal';
+      previewModal.setAttribute('aria-hidden', 'true');
+      previewModal.innerHTML = '<button type="button" class="ever-image-preview-modal-close" aria-label="Close">&times;</button><img src="" alt="">';
+      document.body.appendChild(previewModal);
+
+      var previewImage = previewModal.querySelector('img');
+
+      function closePreviewModal() {
+        previewModal.classList.remove('is-open');
+        previewModal.setAttribute('aria-hidden', 'true');
+        previewImage.setAttribute('src', '');
+      }
+
+      function openPreviewModal(src, alt) {
+        if (!src) {
+          return;
+        }
+
+        previewImage.setAttribute('src', src);
+        previewImage.setAttribute('alt', alt || '');
+        previewModal.classList.add('is-open');
+        previewModal.setAttribute('aria-hidden', 'false');
+      }
+
+      Array.prototype.forEach.call(root.querySelectorAll('.ever-featured-image-preview img'), function (imageNode) {
+        imageNode.addEventListener('click', function () {
+          openPreviewModal(imageNode.getAttribute('data-ever-preview-src') || imageNode.getAttribute('src'), imageNode.getAttribute('alt') || '');
+        });
+      });
+
+      previewModal.addEventListener('click', function (event) {
+        if (event.target === previewModal || event.target.classList.contains('ever-image-preview-modal-close')) {
+          closePreviewModal();
+        }
+      });
+
+      document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+          closePreviewModal();
+        }
       });
     })();
   </script>


### PR DESCRIPTION
### Motivation
- Prevent stale thumbnails in the Back Office by ensuring preview image URLs bypass browser cache after upload. 
- Avoid oversized thumbnails breaking the layout by constraining preview dimensions. 
- Improve UX by allowing quick click-to-preview of images in a modal without leaving the edit form.

### Description
- Add a cache-busting timestamp query parameter via a new helper `appendTimestampToUrl` and apply it to preview URLs used in `AdminBlogImageManager::buildImageHelp`, `AuthorController::buildAuthorImageHelp` and `PostController::buildImageHelp` so previews use `?t=...`.
- Change preview markup to render an inline thumbnail plus a link and add a `data-ever-preview-src` attribute on `<img>` for use by the modal preview logic.
- Update admin modern form styles in `views/templates/admin/modern/form.html.twig` to set `max-width`/`max-height`, change cursor to zoom, and add modal styles for full-size preview.
- Implement client-side modal preview behavior in the same template: create modal element, open on thumbnail click, and close on backdrop click or `Escape` key.

### Testing
- Ran PHP syntax checks: `php -l src/Service/AdminBlogImageManager.php` (passed).
- Ran PHP syntax checks: `php -l src/Controller/Admin/AuthorController.php` (passed).
- Ran PHP syntax checks: `php -l src/Controller/Admin/PostController.php` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea2f990a388325a221caee5f230c5d)