### PR TITLE
Render banner images as CSS backgrounds in front templates

### DIFF
--- a/views/css/everpsblog.css
+++ b/views/css/everpsblog.css
@@ -611,14 +611,12 @@ body#module-everpsblog-post .product-miniature .product-miniature{
 
 #module-everpsblog-post .everpsblog-post-banner {
     width: 100%;
-}
-
-#module-everpsblog-post .everpsblog-post-banner img {
-    display: block;
-    width: 100%;
+    min-height: 260px;
     max-height: 420px;
-    object-fit: cover;
-    background: #fff;
+    height: clamp(260px, 34vw, 420px);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 #module-everpsblog-category .everpsblog-taxonomy-hero-overlay,
@@ -633,16 +631,12 @@ body#module-everpsblog-post .product-miniature .product-miniature{
 #module-everpsblog-author .everpsblog-taxonomy-banner {
     width: 100%;
     margin-top: 1.5rem;
-}
-
-#module-everpsblog-category .everpsblog-taxonomy-banner img,
-#module-everpsblog-tag .everpsblog-taxonomy-banner img,
-#module-everpsblog-author .everpsblog-taxonomy-banner img {
-    display: block;
-    width: 100%;
+    min-height: 260px;
     max-height: 420px;
-    object-fit: cover;
-    background: #fff;
+    height: clamp(260px, 34vw, 420px);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 #module-everpsblog-post .everpsblog-post-title {

--- a/views/templates/front/author.tpl
+++ b/views/templates/front/author.tpl
@@ -83,9 +83,7 @@
                 <div class="everpsblog-taxonomy-hero-overlay">
                     <h1 itemprop="headline" class="m-0 everpsblog-blog-header__title">{$author->nickhandle|escape:'htmlall':'UTF-8'}</h1>
                     {if isset($has_author_banner) && $has_author_banner && isset($author_banner_image) && $author_banner_image}
-                    <div class="everpsblog-taxonomy-banner">
-                        <img src="{$author_banner_image|escape:'htmlall':'UTF-8'}" alt="{$author->nickhandle|escape:'htmlall':'UTF-8'}" title="{$author->nickhandle|escape:'htmlall':'UTF-8'}">
-                    </div>
+                    <div class="everpsblog-taxonomy-banner" style="background-image: url('{$author_banner_image|escape:'htmlall':'UTF-8'}');" aria-label="{$author->nickhandle|escape:'htmlall':'UTF-8'}"></div>
                     {/if}
                     {if isset($author->excerpt) && $author->excerpt}
                         <p class="everpsblog-author-excerpt mt-2 mb-0">{$author->excerpt nofilter}</p>

--- a/views/templates/front/category.tpl
+++ b/views/templates/front/category.tpl
@@ -81,9 +81,7 @@
         <div class="everpsblog-category-hero-overlay">
             <h1 class="m-0 everpsblog-blog-header__title everpsblog-category-title">{$category->title|escape:'htmlall':'UTF-8'}</h1>
             {if isset($has_category_banner) && $has_category_banner && isset($category_banner_image) && $category_banner_image}
-            <div class="everpsblog-taxonomy-banner">
-                <img src="{$category_banner_image|escape:'htmlall':'UTF-8'}" alt="{$category->title|escape:'htmlall':'UTF-8'}" title="{$category->title|escape:'htmlall':'UTF-8'}">
-            </div>
+            <div class="everpsblog-taxonomy-banner" style="background-image: url('{$category_banner_image|escape:'htmlall':'UTF-8'}');" aria-label="{$category->title|escape:'htmlall':'UTF-8'}"></div>
             {/if}
             {if isset($children_categories) && $children_categories && !empty($children_categories)}
             <div class="everpsblog-subcategories everpsblog-blog-header__categories d-flex flex-wrap justify-content-center gap-2 mt-4" role="navigation" aria-label="{l s='Subcategories' d='Modules.Everpsblog.Shop'}">

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -97,9 +97,7 @@
                     <div class="everpsblog-post-hero-overlay">
                         <h1 class="everpsblog-post-title mb-4">{$post->title|escape:'htmlall':'UTF-8'}</h1>
                         {if isset($has_post_banner) && $has_post_banner && isset($post_banner_image) && $post_banner_image}
-                        <div class="everpsblog-post-banner">
-                            <img src="{$post_banner_image|escape:'htmlall':'UTF-8'}" alt="{$post->title|escape:'htmlall':'UTF-8'}" title="{$post->title|escape:'htmlall':'UTF-8'}">
-                        </div>
+                        <div class="everpsblog-post-banner" style="background-image: url('{$post_banner_image|escape:'htmlall':'UTF-8'}');" aria-label="{$post->title|escape:'htmlall':'UTF-8'}"></div>
                         {/if}
                         {if $social_share_links}
                         <div class="social-sharing social-sharing-hero">

--- a/views/templates/front/tag.tpl
+++ b/views/templates/front/tag.tpl
@@ -53,9 +53,7 @@
         <div class="everpsblog-taxonomy-hero-overlay">
             <h1 class="m-0 everpsblog-blog-header__title">{$tag->title|escape:'htmlall':'UTF-8'}</h1>
             {if isset($has_tag_banner) && $has_tag_banner && isset($tag_banner_image) && $tag_banner_image}
-            <div class="everpsblog-taxonomy-banner">
-                <img src="{$tag_banner_image|escape:'htmlall':'UTF-8'}" alt="{$tag->title|escape:'htmlall':'UTF-8'}" title="{$tag->title|escape:'htmlall':'UTF-8'}">
-            </div>
+            <div class="everpsblog-taxonomy-banner" style="background-image: url('{$tag_banner_image|escape:'htmlall':'UTF-8'}');" aria-label="{$tag->title|escape:'htmlall':'UTF-8'}"></div>
             {/if}
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Banner images (author, category, tag, post) were rendered as `<img>` elements but need to be displayed as background images layered on top of the header background color so the configured header color remains the base layer.
- Using background images allows consistent cover/position behavior and responsive sizing for hero banners across front templates.
- Moving to background-image markup also enables simpler styling and better semantics for hero/banner blocks.

### Description
- Replace `<img>` markup with semantic banner blocks that set `style="background-image: url(...)"` in `views/templates/front/author.tpl`, `category.tpl`, `tag.tpl`, and `post.tpl` and add `aria-label` for the banner content.
- Update `views/css/everpsblog.css` to remove rules targeting nested `<img>` and instead set container sizing and background rendering using `min-height`, `max-height`, `height: clamp(...)`, `background-position: center`, `background-size: cover`, and `background-repeat: no-repeat` for `.everpsblog-post-banner` and `.everpsblog-taxonomy-banner`.
- Keep the existing header background color inline style as the base layer so banners render as overlays above the configured color.

### Testing
- Ran `git diff --check` which completed without reported issues.
- Checked repository status with `git status --short` to confirm files were staged/committed; command succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea32f6da6083258a08a38aadd73de3)