### PR TITLE
Render form help HTML and open BO image previews in-modal

### DIFF
--- a/src/Controller/Admin/AuthorController.php
+++ b/src/Controller/Admin/AuthorController.php
@@ -355,11 +355,11 @@ class AuthorController extends AbstractDomainController
         $escapedUrl = htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8');
 
         return sprintf(
-            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%3$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%4$s</a></span></span>',
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%3$s: <button type="button" class="btn btn-link p-0 ever-image-preview-trigger" data-ever-preview-src="%1$s" data-ever-preview-alt="%2$s">%4$s</button></span></span>',
             $escapedUrl,
             htmlspecialchars($this->transAdmin('Current author image'), ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($this->transAdmin('Current image'), ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars($this->transAdmin('open in a new tab'), ENT_QUOTES, 'UTF-8')
+            htmlspecialchars($this->transAdmin('Open preview'), ENT_QUOTES, 'UTF-8')
         );
     }
 
@@ -375,7 +375,7 @@ class AuthorController extends AbstractDomainController
             $this->getContextShopId(),
             'author_banner',
             $this->transAdmin('Current banner image'),
-            $this->transAdmin('open in a new tab')
+            $this->transAdmin('Open preview')
         );
     }
 

--- a/src/Controller/Admin/CategoryController.php
+++ b/src/Controller/Admin/CategoryController.php
@@ -200,7 +200,7 @@ class CategoryController extends AbstractDomainController
             $this->getContextShopId(),
             'category_banner',
             $this->transAdmin('Current banner image'),
-            $this->transAdmin('open in a new tab')
+            $this->transAdmin('Open preview')
         );
     }
 }

--- a/src/Controller/Admin/PostController.php
+++ b/src/Controller/Admin/PostController.php
@@ -560,10 +560,10 @@ class PostController extends AbstractDomainController
         $previewUrl = $this->appendTimestampToUrl($url);
 
         return sprintf(
-            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%3$s</a></span></span>',
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <button type="button" class="btn btn-link p-0 ever-image-preview-trigger" data-ever-preview-src="%1$s" data-ever-preview-alt="%2$s">%3$s</button></span></span>',
             htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
-            htmlspecialchars($this->transAdmin('open in a new tab'), ENT_QUOTES, 'UTF-8')
+            htmlspecialchars($this->transAdmin('Open preview'), ENT_QUOTES, 'UTF-8')
         );
     }
 

--- a/src/Controller/Admin/TagController.php
+++ b/src/Controller/Admin/TagController.php
@@ -182,7 +182,7 @@ class TagController extends AbstractDomainController
             $this->getContextShopId(),
             'tag_banner',
             $this->transAdmin('Current banner image'),
-            $this->transAdmin('open in a new tab')
+            $this->transAdmin('Open preview')
         );
     }
 }

--- a/src/Service/AdminBlogImageManager.php
+++ b/src/Service/AdminBlogImageManager.php
@@ -103,7 +103,7 @@ class AdminBlogImageManager
         $previewUrl = $this->appendTimestampToUrl($url);
 
         return sprintf(
-            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <a href="%1$s" target="_blank" rel="noopener noreferrer">%3$s</a></span></span>',
+            '<span class="ever-featured-image-preview"><img src="%1$s" data-ever-preview-src="%1$s" alt="%2$s" loading="lazy"><span>%2$s: <button type="button" class="btn btn-link p-0 ever-image-preview-trigger" data-ever-preview-src="%1$s" data-ever-preview-alt="%2$s">%3$s</button></span></span>',
             htmlspecialchars($previewUrl, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
             htmlspecialchars($openLabel, ENT_QUOTES, 'UTF-8')

--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -1,5 +1,14 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
+{% block form_help %}
+  {% if help is not empty %}
+    {% set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' form-text text-muted')|trim}) %}
+    <small id="{{ id }}_help"{{ block('attributes') }}>
+      {{- help_html is same as(false) ? help|trans(help_translation_parameters, translation_domain) : help|trans(help_translation_parameters, translation_domain)|raw -}}
+    </small>
+  {% endif %}
+{% endblock %}
+
 {% block stylesheets %}
   {{ parent() }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flatpickr/4.6.13/flatpickr.min.css">
@@ -422,6 +431,7 @@
 {% endblock %}
 
 {% block content %}
+  {% form_theme form _self %}
   {% set contentFields = [] %}
   {% set seoFields = [] %}
   {% set publicationFields = [] %}
@@ -780,6 +790,12 @@
       Array.prototype.forEach.call(root.querySelectorAll('.ever-featured-image-preview img'), function (imageNode) {
         imageNode.addEventListener('click', function () {
           openPreviewModal(imageNode.getAttribute('data-ever-preview-src') || imageNode.getAttribute('src'), imageNode.getAttribute('alt') || '');
+        });
+      });
+
+      Array.prototype.forEach.call(root.querySelectorAll('.ever-image-preview-trigger'), function (triggerNode) {
+        triggerNode.addEventListener('click', function () {
+          openPreviewModal(triggerNode.getAttribute('data-ever-preview-src'), triggerNode.getAttribute('data-ever-preview-alt') || '');
         });
       });
 


### PR DESCRIPTION
### Motivation
- Help text for image fields was being escaped and displayed as raw HTML instead of rendering the preview markup, and preview links opened a new tab instead of showing the image in the admin modal. 
- The change aims to provide an inline preview experience for all back-office entities that use the image upload helper by rendering HTML help and opening previews in the existing modal.

### Description
- Added a `form_help` block to `views/templates/admin/modern/form.html.twig` and applied `form_theme form _self` so field `help_html` is honored and help markup is rendered correctly. 
- Replaced anchor links with an inline preview button by updating `AdminBlogImageManager::buildImageHelp` to emit a `<button class="ever-image-preview-trigger">` and changed the corresponding labels to `Open preview`. 
- Updated controllers (`AuthorController`, `PostController`, `CategoryController`, `TagController`) to use the shared image helper with the new `Open preview` button. 
- Wired the new `.ever-image-preview-trigger` elements to the existing modal in the template JS so clicking the button opens the preview modal (reuses `openPreviewModal`).

### Testing
- Ran PHP lint on modified PHP files: `php -l src/Service/AdminBlogImageManager.php` which returned no syntax errors. 
- Ran `php -l` on each updated controller: `src/Controller/Admin/AuthorController.php`, `src/Controller/Admin/PostController.php`, `src/Controller/Admin/CategoryController.php`, and `src/Controller/Admin/TagController.php`, and all returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3439ea848325b29cea31f2a84edb)