### PR TITLE
Exclude posts without translated title from sitemap generation

### DIFF
--- a/src/Service/BlogSitemapService.php
+++ b/src/Service/BlogSitemapService.php
@@ -124,6 +124,7 @@ class BlogSitemapService
                 LEFT JOIN `' . _DB_PREFIX_ . 'ever_blog_post_shop` ps
                     ON ps.id_ever_post = p.id_ever_post
                 WHERE p.post_status = "published"
+                    AND TRIM(COALESCE(pl.title, "")) != ""
                     AND (p.id_shop = ' . (int) $shopId . ' OR ps.id_shop = ' . (int) $shopId . ')';
         $rows = \Db::getInstance()->executeS($sql) ?: [];
 


### PR DESCRIPTION
### Motivation
- Ensure sitemaps only contain posts that have a non-empty title for the target language so empty translations are not exposed in that language's sitemap.

### Description
- Added a SQL condition in `BlogSitemapService::processSitemapPost` to only select rows where `TRIM(COALESCE(pl.title, "")) != ""`, excluding posts lacking a title in the given `pl.id_lang`.

### Testing
- Ran `php -l src/Service/BlogSitemapService.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea35e9fcc883258c4576d6fc93af66)