### PR TITLE
Restreindre l'utilisation de QCD Page Builder au module activé pour la boutique

### DIFF
--- a/src/Controller/Admin/AbstractDomainController.php
+++ b/src/Controller/Admin/AbstractDomainController.php
@@ -179,13 +179,25 @@ abstract class AbstractDomainController extends FrameworkBundleAdminController
 
     private function isQcdPageBuilderActive(): bool
     {
+        if (!\Module::isInstalled('qcdpagebuilder') || !\Module::isEnabled('qcdpagebuilder')) {
+            return false;
+        }
+
         try {
             $module = \Module::getInstanceByName('qcdpagebuilder');
         } catch (\Throwable $exception) {
             return false;
         }
 
-        return $module instanceof \Module && (bool) $module->active;
+        if (!$module instanceof \Module || !(bool) $module->active) {
+            return false;
+        }
+
+        if (method_exists($module, 'isEnabledForShopContext')) {
+            return (bool) $module->isEnabledForShopContext();
+        }
+
+        return true;
     }
 
     private function buildQcdPageBuilderUrl(string $targetType, int $targetId, string $targetField, int $idLang): string

--- a/src/Controller/Front/AbstractFrontController.php
+++ b/src/Controller/Front/AbstractFrontController.php
@@ -190,8 +190,15 @@ abstract class AbstractFrontController extends \ModuleFrontController
         static $cachedQcdBuilderModuleResolved = false;
 
         if (!$cachedQcdBuilderModuleResolved) {
-            $module = \Module::getInstanceByName('qcdpagebuilder');
-            $cachedQcdBuilderModule = ($module instanceof \Module) ? $module : null;
+            $cachedQcdBuilderModule = null;
+            if (\Module::isInstalled('qcdpagebuilder') && \Module::isEnabled('qcdpagebuilder')) {
+                $module = \Module::getInstanceByName('qcdpagebuilder');
+                if ($module instanceof \Module && (bool) $module->active) {
+                    if (!method_exists($module, 'isEnabledForShopContext') || (bool) $module->isEnabledForShopContext()) {
+                        $cachedQcdBuilderModule = $module;
+                    }
+                }
+            }
             $cachedQcdBuilderModuleResolved = true;
         }
 


### PR DESCRIPTION
### Motivation
- S'assurer que le Page Builder QCD n'est utilisé que si le module `qcdpagebuilder` est réellement installé, activé et disponible pour le contexte boutique courant. 
- Éviter les boutons/admin UI et le rendu front qui invoquent le builder lorsqu'il n'est pas actif pour la boutique afin de garder le comportement de repli sur le contenu natif.

### Description
- Renforcement de la vérification dans `AbstractDomainController::isQcdPageBuilderActive()` pour d'abord valider `Module::isInstalled('qcdpagebuilder')` et `Module::isEnabled('qcdpagebuilder')`, vérifier l'instance et la propriété `active`, puis appeler `isEnabledForShopContext()` si disponible. 
- Mise à jour de `AbstractFrontController::getQcdBuilderModule()` pour ne mettre en cache et retourner le module `qcdpagebuilder` que s'il est installé, activé, actif et (le cas échéant) activé pour le contexte boutique. 
- Comportement de repli inchangé : lorsque le module n'est pas disponible pour la boutique, le code continue de retourner le contenu natif/fallback.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l src/Controller/Admin/AbstractDomainController.php` qui a renvoyé « No syntax errors ». 
- Exécution de la vérification de syntaxe PHP avec `php -l src/Controller/Front/AbstractFrontController.php` qui a renvoyé « No syntax errors ».

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3706a16083259f2450edce50c814)