### PR TITLE
Fix Twig form theme compatibility in admin post form

### DIFF
--- a/views/templates/admin/modern/form.html.twig
+++ b/views/templates/admin/modern/form.html.twig
@@ -1,13 +1,5 @@
 {% extends '@PrestaShop/Admin/layout.html.twig' %}
 
-{% block form_help %}
-  {% if help is not empty %}
-    {% set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' form-text text-muted')|trim}) %}
-    <small id="{{ id }}_help"{{ block('attributes') }}>
-      {{- help_html is same as(false) ? help|trans(help_translation_parameters, translation_domain) : help|trans(help_translation_parameters, translation_domain)|raw -}}
-    </small>
-  {% endif %}
-{% endblock %}
 
 {% block stylesheets %}
   {{ parent() }}
@@ -431,7 +423,6 @@
 {% endblock %}
 
 {% block content %}
-  {% form_theme form _self %}
   {% set contentFields = [] %}
   {% set seoFields = [] %}
   {% set publicationFields = [] %}


### PR DESCRIPTION
### Motivation
- Prevent Twig/Symfony form theme loading from using the current template as a self theme which triggers `Attempted to call an undefined method "getBlocks" of class "Twig\TemplateWrapper"` in some Twig/Symfony version combinations.

### Description
- Removed the local `form_help` block and the `{% form_theme form _self %}` usage from `views/templates/admin/modern/form.html.twig` so the template is no longer applied as its own form theme and won't trigger the legacy `getBlocks()` call path.

### Testing
- Ran `composer validate --no-check-publish` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea385a9a2083258b04953fdd8aaca4)