### PR TITLE
Import bundled translations when a language is installed

### DIFF
--- a/everpsblog.php
+++ b/everpsblog.php
@@ -96,6 +96,7 @@ class EverPsBlog extends Module
         $translationsInstalled = $this->installBundledTranslations();
         // Install
         return parent::install()
+            && $this->registerHook('actionObjectLanguageAddAfter')
             && $this->installModuleTab(
                 'AdminEverPsBlog',
                 'IMPROVE',
@@ -204,6 +205,41 @@ class EverPsBlog extends Module
             );
 
             return false;
+        }
+    }
+
+    /**
+     * Ensure bundled module translations are imported when a new language is installed.
+     *
+     * @param array<string, mixed> $params
+     */
+    public function hookActionObjectLanguageAddAfter(array $params): void
+    {
+        $object = $params['object'] ?? null;
+        if (!$object instanceof \Language) {
+            return;
+        }
+
+        $idLang = (int) $object->id;
+        if ($idLang <= 0) {
+            return;
+        }
+
+        try {
+            $catalog = new \PrestaShop\Module\Everpsblog\Service\ModuleTranslationCatalogService();
+            $catalog->importLanguageFromFile(
+                __DIR__ . '/translations/everpsblog-translations-20260424-170745.json',
+                $idLang
+            );
+        } catch (\Throwable $exception) {
+            \PrestaShopLogger::addLog(
+                sprintf(
+                    '[everpsblog] Unable to import bundled translations for language #%d: %s',
+                    $idLang,
+                    $exception->getMessage()
+                ),
+                3
+            );
         }
     }
 
@@ -1531,6 +1567,7 @@ class EverPsBlog extends Module
             $this->registerHook('displayAdminAfterHeader');
             $this->registerHook('actionAdminMetaAfterWriteRobotsFile');
             $this->registerHook('actionRegisterBlock');
+            $this->registerHook('actionObjectLanguageAddAfter');
         } catch (Exception $e) {
             PrestaShopLogger::addLog($this->name . ' : ' . $e->getMessage());
         }

--- a/src/Service/ModuleTranslationCatalogService.php
+++ b/src/Service/ModuleTranslationCatalogService.php
@@ -183,6 +183,26 @@ class ModuleTranslationCatalogService
         return $this->importFromJson((string) $content);
     }
 
+    public function importLanguageFromFile(string $filePath, int $idLang): array
+    {
+        if ($idLang <= 0 || !is_file($filePath)) {
+            return [
+                'imported' => 0,
+                'skipped' => 0,
+            ];
+        }
+
+        $content = file_get_contents($filePath);
+        if (false === $content || '' === trim($content)) {
+            return [
+                'imported' => 0,
+                'skipped' => 0,
+            ];
+        }
+
+        return $this->importLanguageFromJson((string) $content, $idLang);
+    }
+
     public function deleteModuleTranslations(): int
     {
         if (!$this->translationTableExists()) {
@@ -195,6 +215,63 @@ class ModuleTranslationCatalogService
         );
 
         return (int) \Db::getInstance()->Affected_Rows();
+    }
+
+    public function importLanguageFromJson(string $json, int $idLang): array
+    {
+        if (!$this->translationTableExists()) {
+            throw new \RuntimeException('The PrestaShop translation table is not available.');
+        }
+
+        if ($idLang <= 0) {
+            throw new \InvalidArgumentException('Invalid language identifier.');
+        }
+
+        $payload = json_decode($json, true);
+        if (!is_array($payload) || ($payload['format'] ?? '') !== self::EXPORT_FORMAT) {
+            throw new \InvalidArgumentException('Invalid Ever Blog translation export file.');
+        }
+
+        $targetLanguage = new \Language($idLang);
+        if (!\Validate::isLoadedObject($targetLanguage)) {
+            throw new \InvalidArgumentException('The target language does not exist.');
+        }
+
+        $targetIsoCode = (string) ($targetLanguage->iso_code ?? '');
+        $translations = $payload['translations'] ?? [];
+        $languagePayload = is_array($translations) ? ($translations[$targetIsoCode] ?? null) : null;
+        $items = is_array($languagePayload) ? ($languagePayload['items'] ?? []) : [];
+
+        $stats = [
+            'imported' => 0,
+            'skipped' => 0,
+        ];
+
+        if (!is_array($items)) {
+            return $stats;
+        }
+
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                ++$stats['skipped'];
+                continue;
+            }
+
+            $domain = trim((string) ($item['domain'] ?? ''));
+            $key = trim((string) ($item['key'] ?? ''));
+            $translation = (string) ($item['translation'] ?? '');
+            $theme = $this->normalizeTheme($item['theme'] ?? null);
+
+            if ('' === $domain || '' === $key || !$this->isModuleDomain($domain)) {
+                ++$stats['skipped'];
+                continue;
+            }
+
+            $this->upsertTranslation($idLang, $domain, $key, $translation, $theme);
+            ++$stats['imported'];
+        }
+
+        return $stats;
     }
 
     private function buildExportPayload(array $translations): array


### PR DESCRIPTION
### Motivation
- Ensure the module only imports translations for languages that exist in the shop at module install time, and also import the module's translations for a language if that language is added later.

### Description
- Register the `actionObjectLanguageAddAfter` hook during `install()` and in `checkHooks()` to catch language creation events and ensure the hook is available.
- Add `hookActionObjectLanguageAddAfter()` which imports bundled translations for the newly created language using a targeted import routine when a `Language` object is added.
- Extend `ModuleTranslationCatalogService` with `importLanguageFromFile(string $filePath, int $idLang)` and `importLanguageFromJson(string $json, int $idLang)` to import only the entries for a specific language (resolved via the language ISO code) and upsert them into the translation table.
- Keep the existing module install import behaviour intact: the global import still maps ISO codes to installed `id_lang` and only writes translations for languages present in the shop.

### Testing
- Ran `php -l everpsblog.php` and the file has no syntax errors (success).
- Ran `php -l src/Service/ModuleTranslationCatalogService.php` and the file has no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec586b28e08322a4b5b27ce5a7e914)