### PR TITLE
Empêcher l’incrémentation du compteur de vues pour les admins

### DIFF
--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -209,7 +209,7 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
             Tools::redirect('index.php?controller=404');
         }
         if (!Tools::getValue('preview')) {
-            if ((bool) Tools::isSubmit('everpostcomment') === false) {
+            if ((bool) Tools::isSubmit('everpostcomment') === false && !$this->isAdmin()) {
                 $this->updatePostViewCount(
                     (int) $this->post->id,
                     (int) $this->context->shop->id
@@ -785,6 +785,11 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
             WHERE `id_ever_post` = ' . (int) $idPost . '
                 AND `id_shop` = ' . (int) $idShop
         );
+    }
+
+    private function isAdmin()
+    {
+        return !empty((new Cookie('psAdmin'))->id_employee);
     }
 
     private function getLatestCommentByEmail($email, $idLang): stdClass


### PR DESCRIPTION
### Motivation
- Eviter que les vues d’un article soient comptées lorsque un employé admin consulte la page afin de ne pas fausser les statistiques.

### Description
- Ajout de la condition `!$this->isAdmin()` autour de l’appel à `updatePostViewCount` dans `controllers/front/post.php` et ajout d’une méthode privée `isAdmin()` qui retourne `!empty((new Cookie('psAdmin'))->id_employee)`.

### Testing
- Vérification de syntaxe réalisée avec `php -l controllers/front/post.php` et réussie ("No syntax errors detected").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef827442c8832289dc6be3874dd46c)