### PR TITLE
feat(config): rendre le bloc de résumé IA activable

### DIFF
--- a/controllers/front/post.php
+++ b/controllers/front/post.php
@@ -530,6 +530,10 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
                 }
             }
             $postViewModel = PostViewModel::fromLegacy($this->post);
+            $showAiSummaryBanner = Configuration::get('EVERBLOG_SHOW_AI_SUMMARY_BANNER');
+            if (false === $showAiSummaryBanner) {
+                $showAiSummaryBanner = true;
+            }
             $this->context->smarty->assign([
                 'show_author' => (bool) Configuration::get('EVERBLOG_SHOW_AUTHOR'),
                 'blogcolor' => Configuration::get('EVERBLOG_CSS_FILE'),
@@ -563,6 +567,7 @@ class EverPsBlogpostModuleFrontController extends AbstractFrontController
                 'commentsCount' => (int) $commentsCount,
                 'allow_views_count' => (bool) Configuration::get('EVERBLOG_SHOW_POST_COUNT'),
                 'show_post_tags' => (bool) Configuration::get('EVERBLOG_SHOW_POST_TAGS'),
+                'show_ai_summary_banner' => (bool) $showAiSummaryBanner,
                 'only_logged_comment' => (bool) Configuration::get('EVERBLOG_ONLY_LOGGED_COMMENT'),
             ]);
             $this->setTemplate('module:everpsblog/views/templates/front/post.tpl');

--- a/everpsblog.php
+++ b/everpsblog.php
@@ -150,6 +150,7 @@ class EverPsBlog extends Module
             && Configuration::updateValue('EVERBLOG_SHOW_RELATED_POSTS', 0)
             && Configuration::updateValue('EVERBLOG_SHOW_POST_TAGS', 1)
             && Configuration::updateValue('EVERBLOG_SHOW_AUTHOR', 1)
+            && Configuration::updateValue('EVERBLOG_SHOW_AI_SUMMARY_BANNER', 1)
             && Configuration::updateValue('EVERBLOG_DEFAULT_AUTHOR_NAME', Configuration::get('PS_SHOP_NAME'))
             && Configuration::updateValue('EVERBLOG_DEFAULT_AUTHOR_ID', 0)
             && Configuration::updateValue('EVERBLOG_SITEMAP_NUMBER', 5000)
@@ -180,6 +181,7 @@ class EverPsBlog extends Module
         );
         Configuration::deleteByName('EVERBLOG_CATEG_COLUMNS');
         Configuration::deleteByName('EVERBLOG_SHOW_POST_TAGS');
+        Configuration::deleteByName('EVERBLOG_SHOW_AI_SUMMARY_BANNER');
         Configuration::deleteByName('EVERBLOG_DEFAULT_AUTHOR_ID');
         return $translationsRemoved
             && parent::uninstall()

--- a/src/Controller/Admin/ConfigurationController.php
+++ b/src/Controller/Admin/ConfigurationController.php
@@ -53,6 +53,7 @@ class ConfigurationController extends AbstractDomainController
             'route' => (string) \Configuration::get('EVERPSBLOG_ROUTE'),
             'allow_comments' => (bool) \Configuration::get('EVERBLOG_ALLOW_COMMENTS'),
             'check_comments' => (bool) \Configuration::get('EVERBLOG_CHECK_COMMENTS'),
+            'show_ai_summary_banner' => $this->getBooleanConfiguration('EVERBLOG_SHOW_AI_SUMMARY_BANNER', true),
             'rss_enabled' => $this->getBooleanConfiguration('EVERBLOG_RSS', false),
             'posts_per_page' => (int) \Configuration::get('EVERPSBLOG_PAGINATION'),
             'home_posts' => (int) \Configuration::get('EVERPSBLOG_HOME_NBR'),
@@ -85,6 +86,7 @@ class ConfigurationController extends AbstractDomainController
             \Configuration::updateValue('EVERPSBLOG_ROUTE', (string) $formData['route']);
             \Configuration::updateValue('EVERBLOG_ALLOW_COMMENTS', (bool) $formData['allow_comments']);
             \Configuration::updateValue('EVERBLOG_CHECK_COMMENTS', (bool) $formData['check_comments']);
+            \Configuration::updateValue('EVERBLOG_SHOW_AI_SUMMARY_BANNER', (bool) $formData['show_ai_summary_banner']);
             \Configuration::updateValue('EVERBLOG_RSS', (bool) $formData['rss_enabled']);
             \Configuration::updateValue('EVERPSBLOG_PAGINATION', (int) $formData['posts_per_page']);
             \Configuration::updateValue('EVERPSBLOG_HOME_NBR', (int) $formData['home_posts']);

--- a/src/Form/Type/Admin/ConfigurationType.php
+++ b/src/Form/Type/Admin/ConfigurationType.php
@@ -44,6 +44,10 @@ class ConfigurationType extends AbstractType
                 'label' => 'Moderate comments',
                 'required' => false,
             ])
+            ->add('show_ai_summary_banner', CheckboxType::class, [
+                'label' => 'Show AI summary prompt block on post pages',
+                'required' => false,
+            ])
             ->add('rss_enabled', CheckboxType::class, [
                 'label' => 'Enable RSS feeds',
                 'required' => false,

--- a/views/templates/front/post.tpl
+++ b/views/templates/front/post.tpl
@@ -125,6 +125,7 @@
                     <p class="postexcerpt mb-0">{$post->excerpt nofilter}</p>
                     {/if}
                 </div>
+                {if isset($show_ai_summary_banner) && $show_ai_summary_banner}
                 <section class="ai-summary-banner mb-3" data-qcd-ai-summary-banner="" data-ai-target-domain="{$shop.name|escape:'htmlall':'UTF-8'}">
                     <div class="ai-summary-heading">
                         <strong>{l s='Summarize this post with:' d='Modules.Everpsblog.Shop'}</strong>
@@ -165,6 +166,7 @@
                         </a>
                     </div>
                 </section>
+                {/if}
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Motivation
- Permettre d'activer ou désactiver le bloc de demande de résumé vers des IA depuis la configuration du module afin de contrôler son affichage sur les pages de post.

### Description
- Ajout de la clé de configuration par défaut `EVERBLOG_SHOW_AI_SUMMARY_BANNER` activée à l'installation et supprimée à la désinstallation dans `everpsblog.php`.
- Ajout d'une case à cocher `show_ai_summary_banner` dans le formulaire de configuration BO via `src/Form/Type/Admin/ConfigurationType.php`.
- Chargement et sauvegarde du paramètre dans `src/Controller/Admin/ConfigurationController.php` avec valeur par défaut `true` si absent.
- Transmission de la variable Smarty `show_ai_summary_banner` depuis `controllers/front/post.php` (avec fallback activé) et rendu conditionnel du bloc dans `views/templates/front/post.tpl`.

### Testing
- Vérification syntaxique PHP exécutée avec `php -l` sur `everpsblog.php`, `src/Form/Type/Admin/ConfigurationType.php`, `src/Controller/Admin/ConfigurationController.php` et `controllers/front/post.php`, toutes passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f049510f288322a71d4bbed4f0dadb)